### PR TITLE
[codex] expand stage 0 baseline coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Or run from a local checkout:
 ```bash
 git clone https://github.com/troyzx/CMAT.git
 cd CMAT
-pip install -r requirements.txt
+pip install -r requirements.txt -c constraints.txt
 ```
 
 CMAT is imported as:

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,17 @@
+# Dependency constraints for the CMAT rebuild baseline.
+#
+# Use with:
+#   pip install -r requirements.txt -c constraints.txt
+#
+# The active baseline environment showed numba 0.61.2 installed with
+# llvmlite 0.46.0, which violates numba's own package metadata
+# requirement: llvmlite >=0.44,<0.45. Keep this pair constrained until
+# Stage 1 packaging defines the full supported Python/dependency matrix.
+
+numpy>=1.24,<2.3
+scipy>=1.15,<1.16
+pytransit==2.6.14
+numba==0.61.2
+llvmlite>=0.44,<0.45
+rebound==3.26.3
+emcee==3.1.4

--- a/docs/rebuild/CURRENT_LIMITATIONS.md
+++ b/docs/rebuild/CURRENT_LIMITATIONS.md
@@ -6,7 +6,7 @@ This file separates known limitations from the rebuild roadmap. It should be upd
 
 - The repository currently has no tracked `pyproject.toml`, `setup.cfg`, or `setup.py`; packaging metadata needs to be made explicit in Stage 1.
 - Dependencies are listed without version bounds in `requirements.txt`; `constraints.txt` provides a temporary rebuild-baseline guardrail for the high-risk import stack.
-- `import cmat` fails in the observed local Python 3.11.14 environment because the PyTransit import path reaches an incompatible `numba` / `llvmlite` initialization path.
+- `import cmat` fails in the observed global Python 3.11.14 environment because the PyTransit import path reaches an incompatible `numba` / `llvmlite` initialization path; the constrained disposable environment fixes that dependency pair.
 - The current package import is eager: importing `cmat` imports the light-curve stack even when the user only needs `ttv_sim`.
 - Local ignored build artifacts exist in the workspace (`build/`, `dist/`, egg-info), but they are not part of the tracked source baseline.
 

--- a/docs/rebuild/CURRENT_LIMITATIONS.md
+++ b/docs/rebuild/CURRENT_LIMITATIONS.md
@@ -5,7 +5,7 @@ This file separates known limitations from the rebuild roadmap. It should be upd
 ## Environment and Packaging
 
 - The repository currently has no tracked `pyproject.toml`, `setup.cfg`, or `setup.py`; packaging metadata needs to be made explicit in Stage 1.
-- Dependencies are listed without version bounds in `requirements.txt`.
+- Dependencies are listed without version bounds in `requirements.txt`; `constraints.txt` provides a temporary rebuild-baseline guardrail for the high-risk import stack.
 - `import cmat` fails in the observed local Python 3.11.14 environment because the PyTransit import path reaches an incompatible `numba` / `llvmlite` initialization path.
 - The current package import is eager: importing `cmat` imports the light-curve stack even when the user only needs `ttv_sim`.
 - Local ignored build artifacts exist in the workspace (`build/`, `dist/`, egg-info), but they are not part of the tracked source baseline.

--- a/docs/rebuild/CURRENT_LIMITATIONS.md
+++ b/docs/rebuild/CURRENT_LIMITATIONS.md
@@ -1,0 +1,38 @@
+# Current Limitations
+
+This file separates known limitations from the rebuild roadmap. It should be updated as limitations are resolved, confirmed as scientific scope, or converted into tracked implementation tasks.
+
+## Environment and Packaging
+
+- The repository currently has no tracked `pyproject.toml`, `setup.cfg`, or `setup.py`; packaging metadata needs to be made explicit in Stage 1.
+- Dependencies are listed without version bounds in `requirements.txt`.
+- `import cmat` fails in the observed local Python 3.11.14 environment because the PyTransit import path reaches an incompatible `numba` / `llvmlite` initialization path.
+- The current package import is eager: importing `cmat` imports the light-curve stack even when the user only needs `ttv_sim`.
+- Local ignored build artifacts exist in the workspace (`build/`, `dist/`, egg-info), but they are not part of the tracked source baseline.
+
+## Data and Reproducibility
+
+- The primary workflow is notebook-driven and does not yet save a formal provenance manifest.
+- MCMC settings, optimizer settings, random seeds, dependency versions, and grid definitions are not captured in a machine-readable run record.
+- The example relies on external astronomy services for fresh metadata or downloads when cached data are not used.
+- The cached WASP-44 b data are useful for baseline tests, but they are not a general fixture strategy.
+
+## Testing and Validation
+
+- Stage 0 tests currently protect deterministic scoring helpers and cached WASP-44 b data invariants.
+- The full transit-fitting workflow is not yet covered by automated tests.
+- REBOUND simulation behavior is not yet protected by a reduced deterministic benchmark.
+- MEGNO maps are not yet covered by automated regression checks.
+- There is no CI configuration for tests, linting, or notebook smoke execution.
+
+## Platform and Runtime
+
+- Multiprocessing uses `fork`, which should be reviewed before claiming cross-platform support.
+- Runtime and memory use are not benchmarked across grid sizes.
+- Plotting imports can trigger Matplotlib cache behavior unless a writable `MPLCONFIGDIR` is configured.
+
+## Scientific Scope
+
+- Current constraints are framed for hidden companion mass limits from TTV observations, not full posterior characterization of all possible multiplanet architectures.
+- Model assumptions, prior choices, and rejection thresholds need clearer documentation before broader reuse.
+- Candidate rejection currently depends on grid resolution and selected scoring criteria; those choices should be exposed in benchmark metadata.

--- a/docs/rebuild/CURRENT_LIMITATIONS.md
+++ b/docs/rebuild/CURRENT_LIMITATIONS.md
@@ -19,7 +19,7 @@ This file separates known limitations from the rebuild roadmap. It should be upd
 
 ## Testing and Validation
 
-- Stage 0 tests currently protect deterministic scoring helpers and cached WASP-44 b data invariants.
+- Stage 0 tests currently protect deterministic scoring helpers, TTV residual construction in the constrained environment, and cached WASP-44 b data invariants.
 - The full transit-fitting workflow is not yet covered by automated tests.
 - REBOUND simulation behavior is not yet protected by a reduced deterministic benchmark.
 - MEGNO maps are not yet covered by automated regression checks.

--- a/docs/rebuild/ENVIRONMENT_BASELINE.md
+++ b/docs/rebuild/ENVIRONMENT_BASELINE.md
@@ -89,7 +89,7 @@ env XDG_CACHE_HOME=/private/tmp/cmat-cache \
     python -m unittest discover -s tests
 ```
 
-Result: 5 tests passed.
+Result: 6 tests passed.
 
 ## Current Recommendation
 

--- a/docs/rebuild/ENVIRONMENT_BASELINE.md
+++ b/docs/rebuild/ENVIRONMENT_BASELINE.md
@@ -1,0 +1,52 @@
+# Environment Baseline
+
+This file records the current environment blocker and the repository-level mitigation added before deeper rebuild work.
+
+## Observed Import Failure
+
+The local Python 3.11.14 environment fails on:
+
+```bash
+python -c "import cmat; print(cmat.__all__)"
+```
+
+The failure occurs while `cmat.base` imports PyTransit, which imports Numba and llvmlite:
+
+```text
+RuntimeError: llvmlite.binding.initialize() is deprecated and will be removed.
+LLVM initialization is now handled automatically.
+```
+
+## Root Cause Found Locally
+
+The active environment has an invalid dependency pair:
+
+```text
+numba 0.61.2
+llvmlite 0.46.0
+```
+
+Numba's installed package metadata requires:
+
+```text
+llvmlite >=0.44,<0.45
+```
+
+`python -m pip check` also reports this mismatch directly.
+
+## Repository Mitigation
+
+`constraints.txt` now pins the high-risk import stack used by the rebuild baseline:
+
+```bash
+pip install -r requirements.txt -c constraints.txt
+```
+
+The constraints file is not a final lockfile. It is a narrow guardrail until Stage 1 moves package metadata to `pyproject.toml`, defines supported Python versions, and establishes a tested dependency matrix.
+
+## Current Recommendation
+
+- Do not modify the global Anaconda environment as part of the rebuild.
+- Use a fresh virtual environment for validation.
+- Install source-checkout dependencies with `requirements.txt` plus `constraints.txt`.
+- Treat any remaining import failures as Stage 1 packaging/environment issues before expanding notebook or end-to-end workflow tests.

--- a/docs/rebuild/ENVIRONMENT_BASELINE.md
+++ b/docs/rebuild/ENVIRONMENT_BASELINE.md
@@ -44,9 +44,57 @@ pip install -r requirements.txt -c constraints.txt
 
 The constraints file is not a final lockfile. It is a narrow guardrail until Stage 1 moves package metadata to `pyproject.toml`, defines supported Python versions, and establishes a tested dependency matrix.
 
+## Disposable Environment Validation
+
+A disposable Python 3.11 virtual environment was created under `/private/tmp/cmat-rebuild-env` and installed with:
+
+```bash
+python -m pip install -r requirements.txt -c constraints.txt
+```
+
+The constrained environment resolved the invalid Numba/llvmlite pair:
+
+```text
+numba 0.61.2
+llvmlite 0.44.0
+numpy 2.2.6
+scipy 1.15.3
+```
+
+`python -m pip check` reported:
+
+```text
+No broken requirements found.
+```
+
+In the Codex sandbox, `import cmat` also requires writable cache directories for Matplotlib and ArviZ:
+
+```bash
+env XDG_CACHE_HOME=/private/tmp/cmat-cache \
+    MPLCONFIGDIR=/private/tmp/cmat-mplconfig \
+    python -c "import cmat; print(cmat.__all__)"
+```
+
+Result:
+
+```text
+['Fitlpf', 'ttv_sim']
+```
+
+The same disposable environment passed:
+
+```bash
+env XDG_CACHE_HOME=/private/tmp/cmat-cache \
+    MPLCONFIGDIR=/private/tmp/cmat-mplconfig \
+    python -m unittest discover -s tests
+```
+
+Result: 5 tests passed.
+
 ## Current Recommendation
 
 - Do not modify the global Anaconda environment as part of the rebuild.
 - Use a fresh virtual environment for validation.
 - Install source-checkout dependencies with `requirements.txt` plus `constraints.txt`.
+- Set `XDG_CACHE_HOME` and `MPLCONFIGDIR` to writable paths in sandboxed or restricted environments.
 - Treat any remaining import failures as Stage 1 packaging/environment issues before expanding notebook or end-to-end workflow tests.

--- a/docs/rebuild/STAGE0_BASELINE.md
+++ b/docs/rebuild/STAGE0_BASELINE.md
@@ -72,7 +72,7 @@ Result: passed for all tracked Python modules.
 python -m unittest discover -s tests
 ```
 
-Result: passed 5 tests covering deterministic scoring helpers, first-rejected-mass extraction, and cached WASP-44 b data invariants. The scoring tests load `cmat/ttv_sim.py` directly to avoid the package-level PyTransit import boundary described below.
+Result in the active global environment: 5 tests passed and the TTV residual test skipped because `cmat.base` cannot import through the broken global PyTransit/Numba/llvmlite stack. Result in the constrained disposable environment: 6 tests passed, covering deterministic scoring helpers, TTV residual construction, first-rejected-mass extraction, and cached WASP-44 b data invariants. The scoring tests load `cmat/ttv_sim.py` directly to avoid the package-level PyTransit import boundary described below.
 
 Additional Stage 0 files:
 
@@ -111,7 +111,7 @@ Environment mitigation added after this finding:
 ## Known Risks Before Refactor
 
 - Before this branch, no tracked automated tests or CI configuration protected behavior.
-- The first Stage 0 tests cover deterministic scoring helpers and cached WASP-44 b data invariants; there is still no CI, and the tests do not yet validate the full TESS, MCMC, REBOUND-grid, or MEGNO workflow.
+- The first Stage 0 tests cover deterministic scoring helpers, TTV residual construction when the environment can import `cmat.base`, and cached WASP-44 b data invariants; there is still no CI, and the tests do not yet validate the full TESS, MCMC, REBOUND-grid, or MEGNO workflow.
 - Runtime dependencies are listed without version bounds in `requirements.txt`; `constraints.txt` is a temporary mitigation, not final package metadata.
 - There is no tracked `pyproject.toml`, `setup.cfg`, or `setup.py` packaging metadata in the repository state.
 - Importing `cmat` eagerly imports the light-curve stack, so lightweight use of `ttv_sim` is coupled to PyTransit availability.
@@ -125,7 +125,6 @@ Environment mitigation added after this finding:
 
 Before moving into structural refactoring:
 
-- Add deterministic tests for TTV residual construction once the environment/import path is stable.
 - Implement the reduced WASP-44 b benchmark configuration with expected artifact names and tolerances.
 - Decide supported Python versions and pin or bound high-risk scientific dependencies.
 - Record current limitations separately from rebuild tasks.

--- a/docs/rebuild/STAGE0_BASELINE.md
+++ b/docs/rebuild/STAGE0_BASELINE.md
@@ -106,6 +106,7 @@ Environment mitigation added after this finding:
 
 - `constraints.txt` constrains the high-risk PyTransit/Numba/llvmlite stack.
 - Source checkout installation now uses `pip install -r requirements.txt -c constraints.txt`.
+- A disposable constrained Python 3.11 environment successfully imported `cmat` when `XDG_CACHE_HOME` and `MPLCONFIGDIR` pointed to writable directories.
 
 ## Known Risks Before Refactor
 

--- a/docs/rebuild/STAGE0_BASELINE.md
+++ b/docs/rebuild/STAGE0_BASELINE.md
@@ -77,6 +77,7 @@ Result: passed 5 tests covering deterministic scoring helpers, first-rejected-ma
 Additional Stage 0 files:
 
 - `docs/rebuild/CURRENT_LIMITATIONS.md` records known limitations separately from implementation tasks.
+- `docs/rebuild/ENVIRONMENT_BASELINE.md` records the current import failure and dependency-constraint mitigation.
 - `docs/rebuild/WASP44_REDUCED_BENCHMARK.md` defines the reduced WASP-44 b benchmark contract.
 
 ```bash
@@ -101,11 +102,16 @@ Observed local dependency versions:
 - rebound: 3.26.3
 - emcee: 3.1.4
 
+Environment mitigation added after this finding:
+
+- `constraints.txt` constrains the high-risk PyTransit/Numba/llvmlite stack.
+- Source checkout installation now uses `pip install -r requirements.txt -c constraints.txt`.
+
 ## Known Risks Before Refactor
 
 - Before this branch, no tracked automated tests or CI configuration protected behavior.
 - The first Stage 0 tests cover deterministic scoring helpers and cached WASP-44 b data invariants; there is still no CI, and the tests do not yet validate the full TESS, MCMC, REBOUND-grid, or MEGNO workflow.
-- Runtime dependencies are listed without version bounds.
+- Runtime dependencies are listed without version bounds in `requirements.txt`; `constraints.txt` is a temporary mitigation, not final package metadata.
 - There is no tracked `pyproject.toml`, `setup.cfg`, or `setup.py` packaging metadata in the repository state.
 - Importing `cmat` eagerly imports the light-curve stack, so lightweight use of `ttv_sim` is coupled to PyTransit availability.
 - External data access depends on ExoMAST and MAST availability.
@@ -118,7 +124,7 @@ Observed local dependency versions:
 
 Before moving into structural refactoring:
 
-- Add deterministic tests for TTV residual construction once that math is available without importing the full PyTransit stack.
+- Add deterministic tests for TTV residual construction once the environment/import path is stable.
 - Implement the reduced WASP-44 b benchmark configuration with expected artifact names and tolerances.
 - Decide supported Python versions and pin or bound high-risk scientific dependencies.
 - Record current limitations separately from rebuild tasks.

--- a/docs/rebuild/STAGE0_BASELINE.md
+++ b/docs/rebuild/STAGE0_BASELINE.md
@@ -72,7 +72,12 @@ Result: passed for all tracked Python modules.
 python -m unittest discover -s tests
 ```
 
-Result: passed 2 deterministic scoring tests. The current tests load `cmat/ttv_sim.py` directly to avoid the package-level PyTransit import boundary described below.
+Result: passed 5 tests covering deterministic scoring helpers, first-rejected-mass extraction, and cached WASP-44 b data invariants. The scoring tests load `cmat/ttv_sim.py` directly to avoid the package-level PyTransit import boundary described below.
+
+Additional Stage 0 files:
+
+- `docs/rebuild/CURRENT_LIMITATIONS.md` records known limitations separately from implementation tasks.
+- `docs/rebuild/WASP44_REDUCED_BENCHMARK.md` defines the reduced WASP-44 b benchmark contract.
 
 ```bash
 python -c "import cmat; print(cmat.__all__)"
@@ -99,7 +104,7 @@ Observed local dependency versions:
 ## Known Risks Before Refactor
 
 - Before this branch, no tracked automated tests or CI configuration protected behavior.
-- The first Stage 0 tests cover only deterministic scoring helpers; there is still no CI, and the tests do not yet validate the full TESS, MCMC, REBOUND-grid, or MEGNO workflow.
+- The first Stage 0 tests cover deterministic scoring helpers and cached WASP-44 b data invariants; there is still no CI, and the tests do not yet validate the full TESS, MCMC, REBOUND-grid, or MEGNO workflow.
 - Runtime dependencies are listed without version bounds.
 - There is no tracked `pyproject.toml`, `setup.cfg`, or `setup.py` packaging metadata in the repository state.
 - Importing `cmat` eagerly imports the light-curve stack, so lightweight use of `ttv_sim` is coupled to PyTransit availability.
@@ -113,8 +118,7 @@ Observed local dependency versions:
 
 Before moving into structural refactoring:
 
-- Extend the minimal local test harness beyond scoring helpers.
-- Protect TTV residual calculations with deterministic tests.
-- Define one reduced WASP-44 b benchmark configuration with expected artifact names and tolerances.
+- Add deterministic tests for TTV residual construction once that math is available without importing the full PyTransit stack.
+- Implement the reduced WASP-44 b benchmark configuration with expected artifact names and tolerances.
 - Decide supported Python versions and pin or bound high-risk scientific dependencies.
 - Record current limitations separately from rebuild tasks.

--- a/docs/rebuild/WASP44_REDUCED_BENCHMARK.md
+++ b/docs/rebuild/WASP44_REDUCED_BENCHMARK.md
@@ -1,0 +1,65 @@
+# WASP-44 b Reduced Benchmark
+
+This benchmark defines the smallest useful regression target for the rebuild. It is designed to protect the current workflow without requiring a full production TESS refit or a large REBOUND grid in every local test run.
+
+## Purpose
+
+- Preserve the current WASP-44 b example as the reference scientific workflow.
+- Separate fast deterministic checks from slower simulation and notebook checks.
+- Define expected artifacts before refactoring code paths that produce them.
+
+## Inputs
+
+- Target: `WASP-44 b`
+- Timing residual file: `data/WASP-44 b/tc_data.csv`
+- Metadata file: `data/WASP-44 b/prop_data.csv`
+- Cached TESS products:
+  - `tess2018263035959-s0003-0000000012862099-0123-s_lc.fits`
+  - `tess2018263124740-s0003-s0003-0000000012862099-00405_dvt.fits`
+  - `tess2018267104341-s0003-s0003-0000000012862099-00126_dvt.fits`
+
+## Fast Baseline Invariants
+
+These checks should run in normal unit tests:
+
+- `tc_data.csv` has 8 timing rows.
+- Epoch range is 1218 to 1226.
+- Mean TTV residual is approximately 0 seconds.
+- TTV residual sample standard deviation is approximately 95.55 seconds.
+- Timing uncertainty range is approximately 85.45 to 154.19 seconds.
+- Cached FITS file sizes match the tracked baseline.
+- Synthetic scoring cases preserve current `chi^2`, RMS, and first-rejected-mass behavior.
+
+## Reduced Simulation Benchmark
+
+This tier is intended for a later Stage 0 or Stage 2 follow-up after dependency support is defined.
+
+- Use cached WASP-44 b timing residuals instead of refitting the TESS light curve.
+- Use a small period-ratio grid, for example 3 to 5 `P2/P1` values.
+- Use a small companion-mass grid, for example 3 to 5 mass values.
+- Run REBOUND TTV simulations with fixed configuration and record generated residuals.
+- Compare mass-limit outputs with explicit tolerances.
+- Save machine-readable outputs under a future ignored artifact directory such as `artifacts/stage0/`.
+
+Expected future artifact names:
+
+- `artifacts/stage0/wasp44_ttv_residuals.csv`
+- `artifacts/stage0/wasp44_mass_constraints.csv`
+- `artifacts/stage0/wasp44_megno_grid.csv`
+- `artifacts/stage0/wasp44_benchmark_summary.json`
+
+## Notebook Smoke Benchmark
+
+This tier should run outside the fastest unit-test path:
+
+- Execute a shortened notebook or script path using cached data only.
+- Avoid remote MAST or ExoMAST calls.
+- Use reduced optimizer, sampler, and grid settings.
+- Verify that the workflow produces timing residual, mass-constraint, and plot artifacts.
+
+## Tolerances
+
+- Data-only invariants should be exact except for floating-point summaries.
+- Timing residual summaries should use absolute tolerances at or below `1e-9` seconds where values are read from CSV.
+- Simulation outputs should use looser domain-specific tolerances after the reduced REBOUND benchmark is recorded.
+- Plot artifacts should be checked for existence and nonzero size, not pixel-perfect equality.

--- a/tests/test_ttv_residuals.py
+++ b/tests/test_ttv_residuals.py
@@ -1,0 +1,38 @@
+import importlib
+import unittest
+
+import numpy as np
+
+
+class TtvResidualTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.base = importlib.import_module("cmat.base")
+        except Exception as exc:
+            raise unittest.SkipTest(f"cmat.base import is unavailable: {exc}")
+
+    def test_calculate_ttv_removes_linear_ephemeris_and_centers_residuals(self):
+        fit = self.base.Fitlpf.__new__(self.base.Fitlpf)
+        epochs = np.array([5, 6, 7, 8])
+        epoch_offsets = epochs - epochs[0]
+        residual_days = np.array([0.0, 1.0, -2.0, 1.0]) * 1e-4
+        transit_centers = 100.0 + 2.0 * epoch_offsets + residual_days
+        transit_center_errors = np.array([1.0, 2.0, 3.0, 4.0]) * 1e-5
+
+        fit.epochs = epochs
+        fit.period = self.base.ufloat(2.0, 1e-3)
+        fit.tcs = [
+            self.base.ufloat(center, error)
+            for center, error in zip(transit_centers, transit_center_errors)
+        ]
+
+        fit.calculate_ttv()
+
+        expected_ttv = residual_days * self.base.DAY_TO_SEC
+        expected_ttv_err = (
+            transit_center_errors + fit.period.s * epoch_offsets
+        ) * self.base.DAY_TO_SEC
+        np.testing.assert_allclose(fit.ttv_mcmc_raw, expected_ttv, atol=1e-8)
+        np.testing.assert_allclose(fit.ttv_mcmc, expected_ttv, atol=1e-8)
+        np.testing.assert_allclose(fit.ttv_err, expected_ttv_err, atol=1e-8)

--- a/tests/test_ttv_scoring.py
+++ b/tests/test_ttv_scoring.py
@@ -1,8 +1,15 @@
 import importlib.util
+import os
 from pathlib import Path
+import tempfile
 import unittest
 
 import numpy as np
+
+
+MPLCONFIGDIR = Path(tempfile.gettempdir()) / "cmat-test-mplconfig"
+MPLCONFIGDIR.mkdir(exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", str(MPLCONFIGDIR))
 
 
 def load_ttv_sim_module():
@@ -36,6 +43,37 @@ class TtvScoringTests(unittest.TestCase):
             self.ttv_sim.get_chi2(ttv_rebound, epoch, ttv_mcmc, ttv_err),
             0.0,
         )
+
+    def test_get_m_crit_returns_first_rejected_mass_per_period_ratio(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        sim = self.ttv_sim.ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        low_signal = np.array([0.5, 0.5, 0.5, 0.5])
+        high_signal = np.array([10.0, 10.0, 10.0, 10.0])
+        sim.ttv_results = [
+            low_signal,
+            high_signal,
+            high_signal,
+            high_signal,
+        ]
+
+        chi2_limit, rms_limit = sim.get_m_crit()
+
+        np.testing.assert_array_equal(chi2_limit, np.array([20.0, 10.0]))
+        np.testing.assert_array_equal(rms_limit, np.array([20.0, 10.0]))
 
 
 if __name__ == "__main__":

--- a/tests/test_wasp44_baseline_data.py
+++ b/tests/test_wasp44_baseline_data.py
@@ -1,0 +1,47 @@
+import csv
+from pathlib import Path
+import statistics
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "data" / "WASP-44 b"
+
+
+class Wasp44BaselineDataTests(unittest.TestCase):
+    def test_timing_residual_csv_matches_baseline_summary(self):
+        with (DATA_DIR / "tc_data.csv").open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+
+        epochs = [int(row["epochs"]) for row in rows]
+        residuals = [float(row["ttv_mcmc"]) for row in rows]
+        errors = [float(row["ttv_err"]) for row in rows]
+
+        self.assertEqual(len(rows), 8)
+        self.assertEqual(min(epochs), 1218)
+        self.assertEqual(max(epochs), 1226)
+        self.assertAlmostEqual(statistics.mean(residuals), 0.0, places=10)
+        self.assertAlmostEqual(statistics.stdev(residuals), 95.5548923824639)
+        self.assertAlmostEqual(min(errors), 85.44855678354905)
+        self.assertAlmostEqual(max(errors), 154.19079319858412)
+
+    def test_tracked_tess_fits_files_match_baseline_sizes(self):
+        tess_dir = (
+            DATA_DIR
+            / "mastDownload"
+            / "TESS"
+            / "tess2018263035959-s0003-0000000012862099-0123-s"
+        )
+        expected_sizes = {
+            "tess2018263035959-s0003-0000000012862099-0123-s_lc.fits": 1998720,
+            "tess2018263124740-s0003-s0003-0000000012862099-00405_dvt.fits": 3968640,
+            "tess2018267104341-s0003-s0003-0000000012862099-00126_dvt.fits": 2949120,
+        }
+
+        actual_sizes = {
+            path.name: path.stat().st_size
+            for path in tess_dir.iterdir()
+            if path.suffix == ".fits"
+        }
+
+        self.assertEqual(actual_sizes, expected_sizes)


### PR DESCRIPTION
## Summary

- Adds `docs/rebuild/CURRENT_LIMITATIONS.md` to separate known limitations from roadmap tasks.
- Adds `docs/rebuild/WASP44_REDUCED_BENCHMARK.md` with the reduced WASP-44 b benchmark contract, expected future artifacts, and tolerance strategy.
- Adds `docs/rebuild/ENVIRONMENT_BASELINE.md` and `constraints.txt` to capture and mitigate the current PyTransit/Numba/llvmlite import blocker.
- Updates source-checkout installation docs to use `pip install -r requirements.txt -c constraints.txt`.
- Expands the Stage 0 unittest harness with first-rejected-mass behavior, cached WASP-44 b data invariants, and TTV residual construction coverage.
- Keeps scientific source code and algorithms unchanged.

## Validation

- `git diff --check`
- `python -m compileall cmat`
- Existing global env `python -m unittest discover -s tests` — 5 tests passing, 1 skipped because `cmat.base` cannot import through the broken global dependency stack
- Disposable Python 3.11 venv under `/private/tmp/cmat-rebuild-env` installed successfully with `pip install -r requirements.txt -c constraints.txt`
- Disposable venv `python -m pip check` — no broken requirements
- Disposable venv `import cmat` succeeds with writable `XDG_CACHE_HOME` and `MPLCONFIGDIR`
- Disposable venv `python -m unittest discover -s tests` — 6 tests passing

## Notes

This remains a Stage 0 PR. It establishes baseline guardrails and environment constraints before expanding end-to-end workflow tests or refactoring source code. Do not merge until I explicitly mark it ready for review.