### PR TITLE
Stage 2: validation and notebook smoke baseline

### DIFF
--- a/TODO_industry_rebuild.md
+++ b/TODO_industry_rebuild.md
@@ -24,7 +24,7 @@ This roadmap keeps the current scientific objective intact: constrain hidden com
 - Add small synthetic-system tests with known injected timing offsets and known recovery expectations.
 - Use inject-recovery comparisons to evaluate future scoring backends before replacing the current `chi^2` / RMS baseline.
 - Add regression tests for REBOUND simulation outputs using short, deterministic runs.
-- Add notebook smoke tests that execute a reduced example without requiring a full production grid. Use the cached WASP-44 b data path, skip the remote download cell, reduce the TTV simulation to a minimal deterministic fixture, and leave full-grid and MEGNO sweeps to slower manual validation until a smaller example exists.
+- Add notebook smoke tests that execute a reduced example without requiring a full production grid. _(Started with a cached WASP-44 b forward-simulation slice that skips the remote download and transit-fitting cells, runs a reduced TTV grid, and checks one reduced MEGNO point; full-grid and full-notebook execution are still deferred.)_
 - Configure continuous integration for linting, tests, and notebook execution on a supported Python matrix. _(Started with constrained editable-install validation, `compileall`, and `unittest` on Python 3.10/3.11; notebook smoke execution is still deferred.)_
 
 ## Stage 3: Documentation and Examples

--- a/cmat/ttv_sim.py
+++ b/cmat/ttv_sim.py
@@ -190,7 +190,7 @@ class ttv_sim:
         prop = self.prop
         ms = prop[0]["Ms"]
         mp1 = prop[0]["Mp"]
-        a1 = prop[0]["Ms"]
+        a1 = prop[0]["orbital_distance"]
         a2 = a1 * r ** (2 / 3)
 
         sim = rebound.Simulation()

--- a/docs/rebuild/CURRENT_LIMITATIONS.md
+++ b/docs/rebuild/CURRENT_LIMITATIONS.md
@@ -22,7 +22,7 @@ This file separates known limitations from the rebuild roadmap. It should be upd
 - Stage 0 tests currently protect deterministic scoring helpers, TTV residual construction in the constrained environment, and cached WASP-44 b data invariants.
 - The full transit-fitting workflow is not yet covered by automated tests.
 - A reduced deterministic REBOUND transit-timing fixture now protects one minimal simulation path, but broader instability and grid-behavior coverage is still missing.
-- Notebook smoke execution is still missing; the current reduced plan is to reuse cached WASP-44 b data, skip remote download calls, and clamp the notebook path to minimal TTV simulation coverage instead of the production grid and MEGNO sweeps.
+- Notebook smoke coverage now exercises a reduced cached WASP-44 b forward-simulation slice, but it still skips remote download, transit fitting, and the full production TTV/MEGNO grids from `example.ipynb`.
 - MEGNO maps are not yet covered by automated regression checks.
 - CI now covers constrained editable installs, `compileall`, and the `unittest` suite on Python 3.10 and 3.11, but notebook smoke execution and linting are still not automated.
 

--- a/tests/test_notebook_smoke.py
+++ b/tests/test_notebook_smoke.py
@@ -1,0 +1,68 @@
+import csv
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+import numpy as np
+
+
+MPLCONFIGDIR = Path(tempfile.gettempdir()) / "cmat-test-mplconfig"
+MPLCONFIGDIR.mkdir(exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", str(MPLCONFIGDIR))
+
+from cmat.ttv_sim import ttv_sim
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "data" / "WASP-44 b"
+
+
+class NotebookSmokeTests(unittest.TestCase):
+    def test_reduced_cached_wasp44_path_runs_notebook_forward_slice(self):
+        with (DATA_DIR / "tc_data.csv").open(newline="", encoding="utf-8") as handle:
+            ttv_rows = list(csv.DictReader(handle))
+        with (DATA_DIR / "prop_data.csv").open(newline="", encoding="utf-8") as handle:
+            prop_row = next(csv.DictReader(handle))
+
+        epochs = np.array([int(row["epochs"]) for row in ttv_rows])
+        ttv_mcmc = np.array([float(row["ttv_mcmc"]) for row in ttv_rows])
+        ttv_err = np.array([float(row["ttv_err"]) for row in ttv_rows])
+        prop = [
+            {
+                key: float(prop_row[key])
+                for key in ("orbital_distance", "orbital_period", "Mp", "Ms", "Rs", "Rp")
+            }
+        ]
+
+        simulation = ttv_sim(
+            epochs=epochs,
+            ttv_mcmc=ttv_mcmc,
+            ttv_err=ttv_err,
+            rs=np.array([1.5]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+
+        simulation.ttv_results = [
+            simulation.calculate_rebound((1.5, 10.0)),
+            simulation.calculate_rebound((1.5, 20.0)),
+        ]
+        chi2_limit, rms_limit = simulation.get_m_crit()
+
+        simulation.megno_dt = 0.02
+        simulation.megno_runtime = 50.0
+        megno = simulation.simulation_m((1.5, 10.0))
+
+        self.assertEqual(len(simulation.ttv_results), 2)
+        self.assertTrue(
+            all(result.ndim == 1 and result.size >= len(epochs) for result in simulation.ttv_results)
+        )
+        np.testing.assert_array_equal(chi2_limit, np.array([]))
+        np.testing.assert_array_equal(rms_limit, np.array([]))
+        self.assertTrue(np.isfinite(megno))
+        self.assertGreater(megno, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ttv_rebound.py
+++ b/tests/test_ttv_rebound.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 
@@ -14,6 +15,74 @@ from cmat.ttv_sim import ttv_sim
 
 
 class TtvReboundTests(unittest.TestCase):
+    def test_simulation_m_uses_orbital_distance_for_megno_setup(self):
+        prop = [
+            {
+                "orbital_distance": 0.055,
+                "orbital_period": 4.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+                "Rs": 1.0,
+                "Rp": 1.0,
+            }
+        ]
+        sim = ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([0.0, 0.0, 0.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.5]),
+            mp2s=np.array([10.0]),
+            prop=prop,
+        )
+        sim.megno_dt = 0.1
+        sim.megno_runtime = 10.0
+
+        created = []
+
+        class FakeSimulation:
+            def __init__(self):
+                self.ri_whfast = type("WHFast", (), {"safe_mode": None})()
+                self.particles = [type("Particle", (), {"P": 1.0})()]
+                self.add_calls = []
+                self.dt = None
+                self.exit_max_distance = None
+                created.append(self)
+
+            def add(self, **kwargs):
+                self.add_calls.append(kwargs)
+                self.particles.append(
+                    type("Particle", (), {"P": kwargs.get("a", 1.0)})()
+                )
+
+            def move_to_com(self):
+                return None
+
+            def init_megno(self):
+                return None
+
+            def integrate(self, runtime, exact_finish_time=0):
+                self.integrated_runtime = runtime
+                self.exact_finish_time = exact_finish_time
+
+            def calculate_megno(self):
+                return 2.0
+
+        with patch("cmat.ttv_sim.rebound.Simulation", side_effect=FakeSimulation):
+            megno = sim.simulation_m((1.5, 10.0))
+
+        fake = created[0]
+
+        self.assertEqual(megno, 2.0)
+        self.assertAlmostEqual(fake.add_calls[1]["a"], prop[0]["orbital_distance"])
+        self.assertAlmostEqual(
+            fake.add_calls[2]["a"],
+            prop[0]["orbital_distance"] * 1.5 ** (2 / 3),
+        )
+        self.assertAlmostEqual(
+            fake.dt,
+            sim.megno_dt * min(fake.particles[1].P, fake.particles[2].P),
+        )
+
     def test_calculate_rebound_matches_reduced_deterministic_fixture(self):
         prop = [
             {

--- a/tests/test_ttv_rebound.py
+++ b/tests/test_ttv_rebound.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import patch
+import importlib
 
 import numpy as np
 
@@ -15,6 +16,77 @@ from cmat.ttv_sim import ttv_sim
 
 
 class TtvReboundTests(unittest.TestCase):
+    def test_calculate_rebound_applies_mass_and_radius_unit_conversions(self):
+        prop = [
+            {
+                "orbital_distance": 0.055,
+                "orbital_period": 4.0,
+                "Mp": 1.2,
+                "Ms": 0.95,
+                "Rs": 0.93,
+                "Rp": 1.14,
+            }
+        ]
+        sim = ttv_sim(
+            epochs=np.array([0, 1]),
+            ttv_mcmc=np.array([0.0, 0.0]),
+            ttv_err=np.ones(2),
+            rs=np.array([1.5]),
+            mp2s=np.array([10.0]),
+            prop=prop,
+        )
+        ttv_module = importlib.import_module("cmat.ttv_sim")
+        created = []
+
+        class FakeSimulation:
+            def __init__(self):
+                self.ri_whfast = type("WHFast", (), {"safe_mode": None})()
+                self.t = 0.0
+                self.particles = [
+                    type("Particle", (), {"x": 0.0, "y": 0.0, "P": 1.0})()
+                ]
+                self.add_calls = []
+                created.append(self)
+
+            def add(self, **kwargs):
+                self.add_calls.append(kwargs)
+                self.particles.append(
+                    type(
+                        "Particle",
+                        (),
+                        {"x": 0.0, "y": 0.0, "P": kwargs.get("a", 1.0)},
+                    )()
+                )
+
+            def move_to_com(self):
+                return None
+
+            def integrate(self, *_args, **_kwargs):
+                raise ttv_module.rebound.Escape
+
+        with patch("cmat.ttv_sim.rebound.Simulation", side_effect=FakeSimulation):
+            ttv_rebound = sim.calculate_rebound((1.5, 10.0))
+
+        fake = created[-1]
+
+        self.assertEqual(ttv_rebound.shape, (2,))
+        self.assertAlmostEqual(
+            fake.add_calls[0]["r"],
+            prop[0]["Rs"] * ttv_module.rs_to_AU,
+        )
+        self.assertAlmostEqual(
+            fake.add_calls[1]["m"],
+            prop[0]["Mp"] * ttv_module.mj_to_ms,
+        )
+        self.assertAlmostEqual(
+            fake.add_calls[1]["r"],
+            prop[0]["Rp"] * ttv_module.rj_to_rs * ttv_module.rs_to_AU,
+        )
+        self.assertAlmostEqual(
+            fake.add_calls[2]["m"],
+            10.0 * ttv_module.me_to_ms,
+        )
+
     def test_simulation_m_uses_orbital_distance_for_megno_setup(self):
         prop = [
             {

--- a/tests/test_ttv_scoring.py
+++ b/tests/test_ttv_scoring.py
@@ -35,6 +35,23 @@ class TtvScoringTests(unittest.TestCase):
             0.0,
         )
 
+    def test_get_chi2_prefers_recovering_injected_signal(self):
+        epoch = np.array([10, 11, 12, 13])
+        ttv_err = np.full(4, 0.2)
+        injected_signal = np.array([4.0, 1.5, -2.0, 3.0, -1.0, 0.5])
+        recovered_ttv = injected_signal[1:5] + np.array([0.05, -0.05, 0.1, -0.1])
+        mismatched_signal = np.array([4.0, -1.5, 2.0, -3.0, 1.0, -0.5])
+
+        recovered_score = scoring.get_chi2(
+            injected_signal, epoch, recovered_ttv, ttv_err
+        )
+        mismatched_score = scoring.get_chi2(
+            mismatched_signal, epoch, recovered_ttv, ttv_err
+        )
+
+        self.assertLess(recovered_score, 1.0)
+        self.assertGreater(mismatched_score, recovered_score)
+
     def test_legacy_scoring_functions_remain_on_ttv_module(self):
         ttv_module = importlib.import_module("cmat.ttv_sim")
 
@@ -127,6 +144,36 @@ class TtvScoringTests(unittest.TestCase):
 
         np.testing.assert_array_equal(chi2_limit, np.array([]))
         np.testing.assert_array_equal(rms_limit, np.array([]))
+
+    def test_get_m_crit_recovers_injected_signal_until_larger_mass_is_rejected(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        injected_signal = np.array([1.0, -1.0, 2.0])
+        sim = ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=injected_signal,
+            ttv_err=np.full(3, 0.2),
+            rs=np.array([1.0, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        sim.ttv_results = [
+            np.array([1.0, -1.0, 2.0, 0.5]),
+            np.array([0.9, -0.9, 1.8, 0.4]),
+            np.array([4.0, -4.0, 8.0, 2.0]),
+            np.array([3.6, -3.6, 7.2, 1.6]),
+        ]
+
+        chi2_limit, rms_limit = sim.get_m_crit()
+
+        np.testing.assert_array_equal(chi2_limit, np.array([20.0, 20.0]))
+        np.testing.assert_array_equal(rms_limit, np.array([20.0, 20.0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add reduced synthetic inject-recovery coverage for the existing `chi^2` and mass-threshold scoring path
- fix MEGNO setup so the primary semimajor axis uses orbital distance, and protect that wiring with a structural regression test
- add unit-conversion coverage for the forward-simulation mass and radius scaling used when building REBOUND systems
- add a reduced cached-data notebook smoke test that exercises the forward-simulation half of the WASP-44 b example without remote downloads or production-scale grids
- update the Stage 2 roadmap and current limitations notes to reflect the reduced notebook smoke coverage now in place

## Validation
- `MPLCONFIGDIR=/private/tmp/cmat-mplconfig XDG_CACHE_HOME=/private/tmp/cmat-cache /private/tmp/cmat-rebuild-env/bin/python -m unittest -v tests.test_ttv_scoring`
- `MPLCONFIGDIR=/private/tmp/cmat-mplconfig XDG_CACHE_HOME=/private/tmp/cmat-cache /private/tmp/cmat-rebuild-env/bin/python -m unittest -v tests.test_ttv_rebound`
- `MPLCONFIGDIR=/private/tmp/cmat-mplconfig XDG_CACHE_HOME=/private/tmp/cmat-cache /private/tmp/cmat-rebuild-env/bin/python -m unittest -v tests.test_notebook_smoke`
- `MPLCONFIGDIR=/private/tmp/cmat-mplconfig XDG_CACHE_HOME=/private/tmp/cmat-cache /private/tmp/cmat-rebuild-env/bin/python -m unittest discover -v -s tests` (30 passed)

## Base Branch
This PR targets `dev/industry-rebuild` so Stage 2 validation can be reviewed independently from the final integration into `main`.
