### PR TITLE
Stage 3: split documentation surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,20 @@ This repository is research software. The code is useful as a worked scientific 
 
 - `cmat/` - Python source code for TESS light-curve fitting, transit-center inference, TTV construction, REBOUND simulations, mass-limit estimation, and MEGNO mapping.
 - `data/WASP-44 b/` - example TESS and CSV data used by the included notebook.
+- `docs/` - user-facing installation, quick-start, theory, API, data-format, and troubleshooting guides.
 - `example.ipynb` - end-to-end example notebook for WASP-44 b.
 - `requirements.txt` - runtime dependencies.
 - `LICENSE` - GNU General Public License v3.0.
+
+## Documentation
+
+- [Installation](docs/INSTALLATION.md)
+- [Quick Start](docs/QUICKSTART.md)
+- [Theory](docs/THEORY.md)
+- [API Reference](docs/API_REFERENCE.md)
+- [Data Formats](docs/DATA_FORMATS.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [Rebuild Notes](docs/rebuild/)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository is research software. The code is useful as a worked scientific 
 - `cmat/` - Python source code for TESS light-curve fitting, transit-center inference, TTV construction, REBOUND simulations, mass-limit estimation, and MEGNO mapping.
 - `data/WASP-44 b/` - example TESS and CSV data used by the included notebook.
 - `docs/` - user-facing installation, quick-start, theory, API, data-format, and troubleshooting guides.
-- `examples/` - small self-contained example scripts that avoid the full notebook workflow.
+- `examples/` - small self-contained example scripts and notebooks that avoid the full notebook workflow.
 - `example.ipynb` - end-to-end example notebook for WASP-44 b.
 - `requirements.txt` - runtime dependencies.
 - `LICENSE` - GNU General Public License v3.0.
@@ -62,13 +62,19 @@ import cmat
 
 ## Example Notebook
 
-Run the included notebook:
+Run the included full notebook:
 
 ```bash
 jupyter notebook example.ipynb
 ```
 
 The notebook uses the provided WASP-44 b data to demonstrate target setup, TESS data access, transit fitting, TTV residual construction, companion-mass grid simulation, and MEGNO visualization.
+
+For a lighter interactive example that avoids remote data access and transit fitting, run:
+
+```bash
+jupyter notebook examples/synthetic_ttv_quickstart.ipynb
+```
 
 ## Workflow: TESS Light Curves to Upper Mass Constraints
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository is research software. The code is useful as a worked scientific 
 - `cmat/` - Python source code for TESS light-curve fitting, transit-center inference, TTV construction, REBOUND simulations, mass-limit estimation, and MEGNO mapping.
 - `data/WASP-44 b/` - example TESS and CSV data used by the included notebook.
 - `docs/` - user-facing installation, quick-start, theory, API, data-format, and troubleshooting guides.
+- `examples/` - small self-contained example scripts that avoid the full notebook workflow.
 - `example.ipynb` - end-to-end example notebook for WASP-44 b.
 - `requirements.txt` - runtime dependencies.
 - `LICENSE` - GNU General Public License v3.0.

--- a/TODO_industry_rebuild.md
+++ b/TODO_industry_rebuild.md
@@ -30,7 +30,7 @@ This roadmap keeps the current scientific objective intact: constrain hidden com
 ## Stage 3: Documentation and Examples
 
 - Split the documentation into installation, quick start, theory, API reference, data formats, and troubleshooting.
-- Keep `example.ipynb` as the narrative astronomy workflow and add a smaller quick-start notebook for fast validation.
+- Keep `example.ipynb` as the narrative astronomy workflow and add a smaller quick-start notebook for fast validation. _(Started with `examples/synthetic_ttv_quickstart.ipynb`.)_
 - Add a synthetic-data example that does not require remote TESS queries.
 - Document input schemas for FITS products, transit-center CSV files, and planetary metadata.
 - Add interpretation guidance for mass-limit curves, MEGNO maps, unstable configurations, and observational caveats.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -16,6 +16,38 @@ import cmat
 - `cmat.OutputConfig` - artifact output paths
 - `cmat.RunConfig` - composite workflow configuration
 
+## Preferred boundary
+
+For new code, prefer the configuration and workflow modules over reaching directly into notebook-era internals.
+
+Example:
+
+```python
+import numpy as np
+
+from cmat.config import RunConfig, SimulationGrid, TargetConfig
+from cmat.workflow import make_ttv_simulation
+
+config = RunConfig(
+    target=TargetConfig("WASP-44 b"),
+    simulation=SimulationGrid(
+        period_ratios=[1.5, 2.0],
+        companion_masses=[10.0, 20.0],
+        n_transit_simulations=6,
+        megno_dt=0.1,
+        megno_runtime=100.0,
+    ),
+)
+
+simulation = make_ttv_simulation(
+    config,
+    epochs=np.array([0, 1, 2]),
+    ttv_mcmc=np.array([0.0, 1.0, 0.0]),
+    ttv_err=np.ones(3),
+    prop=[{"orbital_distance": 1.0, "orbital_period": 1.0, "Mp": 1.0, "Ms": 1.0}],
+)
+```
+
 ## Modules
 
 ### `cmat.base`
@@ -40,13 +72,27 @@ Contains the current forward-simulation workflow for:
 
 Typed dataclasses for structured workflow inputs.
 
+- `TargetConfig` - target name, local data root, product subgroup selection
+- `FitControls` - optimizer and sampler counts
+- `SimulationGrid` - period ratios, companion masses, and MEGNO controls
+- `OutputConfig` - output directories and metadata destinations
+- `RunConfig` - composite run configuration
+
 ### `cmat.workflow`
 
 Thin adapters from typed configuration objects to the existing workflow classes.
 
+- `legacy_data_dir(target)` - normalize a `TargetConfig` to the current `Fitlpf` data-root string
+- `make_fit_lpf(target)` - build a legacy `Fitlpf` object from a typed target config
+- `make_ttv_simulation(config, ...)` - build a `ttv_sim` object from typed simulation settings and TTV arrays
+- `workflow_manifest(config, ...)` - build a JSON-serializable run manifest
+
 ### `cmat.scoring`
 
 Scoring helpers for comparing simulated and observed TTV residuals.
+
+- `get_chi2(...)` - minimum aligned `chi^2` score over discrete epoch offsets
+- `get_rms(...)` - root-mean-square amplitude of a simulated TTV series
 
 ## Stability note
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,53 @@
+# API Reference
+
+CMAT's public surface is still evolving. The current practical entry points are:
+
+## Top-level imports
+
+```python
+import cmat
+```
+
+- `cmat.Fitlpf` - transit-fitting workflow object
+- `cmat.ttv_sim` - TTV and MEGNO forward-simulation workflow object
+- `cmat.TargetConfig` - target metadata and data-root configuration
+- `cmat.FitControls` - fitting iteration and sampler controls
+- `cmat.SimulationGrid` - period-ratio, mass-grid, and MEGNO controls
+- `cmat.OutputConfig` - artifact output paths
+- `cmat.RunConfig` - composite workflow configuration
+
+## Modules
+
+### `cmat.base`
+
+Contains the current `Fitlpf` implementation for:
+
+- target parameter setup
+- TESS light-curve fitting
+- posterior transit-center extraction
+- TTV residual construction
+
+### `cmat.ttv_sim`
+
+Contains the current forward-simulation workflow for:
+
+- REBOUND TTV generation
+- mass-threshold extraction
+- MEGNO simulation
+- plotting helpers
+
+### `cmat.config`
+
+Typed dataclasses for structured workflow inputs.
+
+### `cmat.workflow`
+
+Thin adapters from typed configuration objects to the existing workflow classes.
+
+### `cmat.scoring`
+
+Scoring helpers for comparing simulated and observed TTV residuals.
+
+## Stability note
+
+The configuration and workflow modules are the preferred boundary for future refactors. The lower-level fitting and simulation internals should still be treated as rebuild-era APIs rather than a finalized stable interface.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -18,15 +18,15 @@ import cmat
 
 ## Preferred boundary
 
-For new code, prefer the configuration and workflow modules over reaching directly into notebook-era internals.
+For new code, prefer the configuration and workflow modules over reaching directly into notebook-era internals. That boundary is where the rebuild is making inputs explicit and JSON-serializable without changing the scientific implementation underneath.
 
 Example:
 
 ```python
 import numpy as np
 
-from cmat.config import RunConfig, SimulationGrid, TargetConfig
-from cmat.workflow import make_ttv_simulation
+from cmat.config import OutputConfig, RunConfig, SimulationGrid, TargetConfig
+from cmat.workflow import make_ttv_simulation, workflow_manifest
 
 config = RunConfig(
     target=TargetConfig("WASP-44 b"),
@@ -37,6 +37,8 @@ config = RunConfig(
         megno_dt=0.1,
         megno_runtime=100.0,
     ),
+    output=OutputConfig(root_dir="artifacts", run_name="wasp44b-reduced"),
+    random_seed=42,
 )
 
 simulation = make_ttv_simulation(
@@ -44,55 +46,199 @@ simulation = make_ttv_simulation(
     epochs=np.array([0, 1, 2]),
     ttv_mcmc=np.array([0.0, 1.0, 0.0]),
     ttv_err=np.ones(3),
-    prop=[{"orbital_distance": 1.0, "orbital_period": 1.0, "Mp": 1.0, "Ms": 1.0}],
+    prop=[{"orbital_distance": 1.0, "orbital_period": 1.0, "Mp": 1.0, "Ms": 1.0, "Rs": 1.0, "Rp": 1.0}],
 )
+manifest = workflow_manifest(config, dependency_versions={"numpy": "2.x"})
 ```
 
-## Modules
+## Configuration objects
 
-### `cmat.base`
+### `TargetConfig`
 
-Contains the current `Fitlpf` implementation for:
+Target-level inputs for data discovery and local storage.
 
-- target parameter setup
-- TESS light-curve fitting
-- posterior transit-center extraction
-- TTV residual construction
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `planet_name` | `str` | required | Must be a non-empty string |
+| `data_dir` | `Path \| str` | `Path("data")` | Root directory containing per-target folders |
+| `product_subgroups` | iterable of `str` | `("LC",)` | Must contain at least one non-empty value |
 
-### `cmat.ttv_sim`
+Derived property:
 
-Contains the current forward-simulation workflow for:
+- `target_data_dir` - `data_dir / planet_name`
 
-- REBOUND TTV generation
-- mass-threshold extraction
-- MEGNO simulation
-- plotting helpers
+Serialization helper:
 
-### `cmat.config`
+- `to_dict()` - returns a JSON-friendly target description
 
-Typed dataclasses for structured workflow inputs.
+### `FitControls`
 
-- `TargetConfig` - target name, local data root, product subgroup selection
-- `FitControls` - optimizer and sampler counts
-- `SimulationGrid` - period ratios, companion masses, and MEGNO controls
-- `OutputConfig` - output directories and metadata destinations
-- `RunConfig` - composite run configuration
+Optimizer and sampler controls for the light-curve fitting stages.
 
-### `cmat.workflow`
+| Field | Default |
+| --- | --- |
+| `global_niter` | `200` |
+| `global_npop` | `30` |
+| `single_niter` | `100` |
+| `single_npop` | `50` |
+| `mcmc_steps` | `2500` |
+| `mcmc_thin` | `25` |
+| `mcmc_repeats` | `4` |
 
-Thin adapters from typed configuration objects to the existing workflow classes.
+All fields must be positive integers.
 
-- `legacy_data_dir(target)` - normalize a `TargetConfig` to the current `Fitlpf` data-root string
-- `make_fit_lpf(target)` - build a legacy `Fitlpf` object from a typed target config
-- `make_ttv_simulation(config, ...)` - build a `ttv_sim` object from typed simulation settings and TTV arrays
-- `workflow_manifest(config, ...)` - build a JSON-serializable run manifest
+### `SimulationGrid`
 
-### `cmat.scoring`
+Forward-simulation grid for companion period ratios and masses.
 
-Scoring helpers for comparing simulated and observed TTV residuals.
+| Field | Type | Default | Validation |
+| --- | --- | --- | --- |
+| `period_ratios` | 1D iterable of float | required | finite, positive, non-empty |
+| `companion_masses` | 1D iterable of float | required | finite, positive, non-empty, strictly increasing |
+| `n_transit_simulations` | `int` | `80` | positive integer |
+| `megno_dt` | `float` | `1/20` | finite, positive |
+| `megno_runtime` | `float` | `1e4` | finite, positive |
 
-- `get_chi2(...)` - minimum aligned `chi^2` score over discrete epoch offsets
-- `get_rms(...)` - root-mean-square amplitude of a simulated TTV series
+Key helpers:
+
+- `parameter_count` - total number of `(period_ratio, companion_mass)` pairs
+- `parameter_pairs()` - list of parameter tuples in the same mass-major ordering used by the current simulation loops
+- `to_dict()` - JSON-friendly grid description
+
+### `OutputConfig`
+
+Filesystem destinations for run artifacts.
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `root_dir` | `Path \| str` | `Path("artifacts")` | Base artifact directory |
+| `run_name` | `str \| None` | `None` | Optional per-run subdirectory |
+
+Derived properties:
+
+- `run_dir` - `root_dir` or `root_dir / run_name`
+- `tables_dir` - `run_dir / "tables"`
+- `figures_dir` - `run_dir / "figures"`
+- `metadata_path` - `run_dir / "run_metadata.json"`
+
+### `RunConfig`
+
+Composite configuration for fitting and simulation runs.
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `target` | `TargetConfig` | required | mandatory |
+| `fit` | `FitControls` | default factory | fitting controls |
+| `simulation` | `SimulationGrid \| None` | `None` | required by `make_ttv_simulation(...)` |
+| `output` | `OutputConfig` | default factory | artifact destinations |
+| `random_seed` | `int \| None` | `None` | must be non-negative if provided |
+
+`RunConfig.to_dict()` returns a fully JSON-serializable nested configuration object.
+
+## Workflow adapters
+
+The `cmat.workflow` module provides the current rebuild boundary around the legacy classes.
+
+| Function | Returns | Purpose |
+| --- | --- | --- |
+| `legacy_data_dir(target)` | `str` | Normalizes `TargetConfig.data_dir` to the trailing-slash string expected by `Fitlpf` |
+| `make_fit_lpf(target)` | `Fitlpf` | Builds a legacy transit-fitting object from a typed target config |
+| `make_ttv_simulation(config, *, epochs, ttv_mcmc, ttv_err, prop)` | `ttv_sim` | Builds a forward-simulation object from typed config plus observed TTV arrays |
+| `workflow_manifest(config, *, dependency_versions=None, notes=None)` | `dict` | Builds a JSON-serializable run manifest |
+
+### `make_ttv_simulation(...)` input contract
+
+`make_ttv_simulation(...)` currently expects:
+
+- `config.simulation` to be present
+- `epochs`, `ttv_mcmc`, and `ttv_err` to be aligned one-dimensional arrays
+- `prop` to be a list whose first item contains at least:
+  - `orbital_distance`
+  - `orbital_period`
+  - `Mp`
+  - `Ms`
+  - `Rs`
+  - `Rp`
+
+The adapter forwards:
+
+- `SimulationGrid.period_ratios` -> `ttv_sim.rs`
+- `SimulationGrid.companion_masses` -> `ttv_sim.mp2s`
+- `SimulationGrid.n_transit_simulations` -> `ttv_sim.N`
+- `SimulationGrid.megno_dt` / `megno_runtime` -> mutable MEGNO controls on the returned object
+
+## Scoring helpers
+
+The `cmat.scoring` module contains the current comparison helpers used by the forward-simulation workflow.
+
+| Function | Purpose |
+| --- | --- |
+| `get_chi2(ttv_rebound, epoch, ttv_mcmc, ttv_err)` | Minimum aligned `chi^2` score over discrete epoch offsets |
+| `get_rms(ttv_rebound)` | Root-mean-square amplitude of a simulated TTV series |
+| `get_chi2_v(...)` | Vectorized form of `get_chi2` used across simulation grids |
+| `get_rms_v(...)` | Vectorized form of `get_rms` used across simulation grids |
+
+## Legacy workflow classes
+
+The classes below are still important, but they remain rebuild-era APIs rather than the preferred long-term boundary.
+
+### `cmat.base.Fitlpf`
+
+Constructor:
+
+```python
+Fitlpf(planet_name: str, datadir=None)
+```
+
+Primary responsibilities:
+
+- fetch target metadata and TESS identifiers
+- download and fit light curves
+- extract posterior transit centers
+- derive transit epochs and TTV residuals
+
+Common call sequence in the current notebook-era workflow:
+
+1. `get_parameter()`
+2. `download_data()` / `de(...)`
+3. `fit_singles()`
+4. `get_posterior_samples()`
+5. `calculate_ttv()`
+6. `plot_tcs()` / `plot_ttv_re()`
+
+Operational note: this is the most environment-sensitive surface because it depends on the PyTransit stack.
+
+### `cmat.ttv_sim.ttv_sim`
+
+Constructor:
+
+```python
+ttv_sim(epochs, ttv_mcmc, ttv_err, rs, mp2s, prop, N=80)
+```
+
+Key constructor inputs:
+
+- `epochs` - observed transit epochs
+- `ttv_mcmc` - observed timing residuals in seconds
+- `ttv_err` - timing uncertainties in seconds
+- `rs` - companion-to-primary period-ratio grid
+- `mp2s` - companion-mass grid
+- `prop` - list containing at least one target-property dictionary
+- `N` - number of transit simulations to generate
+
+Important attributes and methods:
+
+| Name | Kind | Purpose |
+| --- | --- | --- |
+| `calculate_rebound((r, mp2))` | method | Simulate one REBOUND TTV series for a single grid point |
+| `get_ttv_rebound_all(number_of_thread)` | method | Run REBOUND across the full grid in parallel |
+| `get_m_crit()` | method | Compute first rejected companion masses for the current `chi^2` and RMS thresholds |
+| `simulation_m((r, mp2))` | method | Run one MEGNO simulation |
+| `run_megno(number_of_threads)` | method | Run MEGNO across the full grid |
+| `plot_megno()` | method | Plot the MEGNO map |
+| `megno_dt` / `megno_runtime` | attributes | Controls for MEGNO timestep and integration runtime |
+
+`get_m_crit()` returns two arrays: the first rejected masses under the current `chi^2` threshold and the first rejected masses under the current RMS threshold. A period-ratio column only contributes an entry if the reduced grid actually crosses the corresponding rejection criterion.
 
 ## Stability note
 

--- a/docs/DATA_FORMATS.md
+++ b/docs/DATA_FORMATS.md
@@ -25,6 +25,12 @@ Current columns:
 
 This file is the lightest cached input for the reduced notebook smoke path.
 
+Typical workflow use:
+
+- `epochs` indexes the observed transit events
+- `ttv_mcmc` provides the residual series used for TTV comparison
+- `ttv_err` provides the timing uncertainty used by the current `chi^2` scoring path
+
 ## `prop_data.csv`
 
 This cached table contains target and system metadata used by the notebook and forward simulation, including:
@@ -43,6 +49,12 @@ The reduced notebook smoke path currently reads:
 - `Rs`
 - `Rp`
 
+These fields are enough to instantiate the current `ttv_sim` forward model on cached data.
+
 ## FITS products
 
 The cached FITS files under `mastDownload/TESS/` are the notebook's example TESS products. They remain part of the narrative workflow, but the reduced validation path intentionally avoids requiring a full transit-fitting rerun on them.
+
+## Stability note
+
+The current data-format coverage is intentionally pragmatic rather than exhaustive. The rebuild still needs a more formal schema description for the notebook-era FITS inputs and for any future saved run manifests.

--- a/docs/DATA_FORMATS.md
+++ b/docs/DATA_FORMATS.md
@@ -10,20 +10,24 @@ data/WASP-44 b/
 
 Current tracked files include:
 
-- `prop_data.csv` - cached target and system properties
-- `tc_data.csv` - cached transit-timing residuals and timing uncertainties
-- `mastDownload/TESS/.../*.fits` - cached TESS products used by the notebook workflow
+| Path | Purpose | Used by |
+| --- | --- | --- |
+| `data/WASP-44 b/prop_data.csv` | Cached target and system properties | notebook workflow, reduced forward-simulation path |
+| `data/WASP-44 b/tc_data.csv` | Cached transit-timing residuals and timing uncertainties | reduced smoke test, reduced forward-simulation path |
+| `data/WASP-44 b/mastDownload/TESS/.../*.fits` | Cached TESS products | full notebook-era fitting workflow |
 
 ## `tc_data.csv`
 
+This is the lightest cached input for the reduced notebook smoke path.
+
 Current columns:
 
-- unnamed row index column
-- `ttv_mcmc` - inferred transit timing residual in seconds
-- `ttv_err` - timing uncertainty in seconds
-- `epochs` - integer transit epoch index
-
-This file is the lightest cached input for the reduced notebook smoke path.
+| Column | Type | Units | Meaning | Notes |
+| --- | --- | --- | --- | --- |
+| *(unnamed first column)* | integer-like | none | Row index written by the original pandas export | Safe to ignore, or read as an index column |
+| `ttv_mcmc` | float | seconds | Inferred transit timing residual | Centered residual series used by the current scoring path |
+| `ttv_err` | float | seconds | Timing uncertainty for each observed transit | Used directly by the current `chi^2` scoring path |
+| `epochs` | integer | transit count | Transit epoch index | Must stay aligned with `ttv_mcmc` and `ttv_err` |
 
 Typical workflow use:
 
@@ -31,30 +35,94 @@ Typical workflow use:
 - `ttv_mcmc` provides the residual series used for TTV comparison
 - `ttv_err` provides the timing uncertainty used by the current `chi^2` scoring path
 
+The reduced smoke path and synthetic examples assume all three scientific columns can be loaded into one-dimensional NumPy arrays of equal length.
+
 ## `prop_data.csv`
 
-This cached table contains target and system metadata used by the notebook and forward simulation, including:
+This cached table contains target and system metadata used by the notebook and forward simulation. The repository example is a wide, metadata-rich table rather than a minimal simulation-only schema.
 
-- stellar radius and mass (`Rs`, `Ms`)
-- planetary radius and mass (`Rp`, `Mp`)
-- orbital period and semimajor axis (`orbital_period`, `orbital_distance`)
-- transit timing reference fields
+The current file follows a repeated field-family pattern:
 
-The reduced notebook smoke path currently reads:
+| Field family | Meaning |
+| --- | --- |
+| `<field>` | Nominal numeric value |
+| `<field>_unit` | Unit label stored in the CSV |
+| `<field>_upper` / `<field>_lower` | Upper and lower uncertainty values |
+| `<field>_ref` | Reference citation string |
+| `<field>_url` | Source URL |
 
-- `orbital_distance`
-- `orbital_period`
-- `Mp`
-- `Ms`
-- `Rs`
-- `Rp`
+Examples of these families in the current repository data include stellar parameters, planetary parameters, orbital parameters, photometric magnitudes, and transit-reference metadata.
 
-These fields are enough to instantiate the current `ttv_sim` forward model on cached data.
+### Minimal fields required by the current forward-simulation path
+
+The reduced notebook smoke path currently reads only the following numeric fields:
+
+| Field | Example unit in repository data | Meaning | Required by |
+| --- | --- | --- | --- |
+| `orbital_distance` | `AU` | Semimajor axis of the observed planet | `ttv_sim` setup |
+| `orbital_period` | `d` | Orbital period of the observed planet | forward simulation context |
+| `Mp` | `M_Jupiter` | Mass of the observed planet | REBOUND primary-planet setup |
+| `Ms` | `M_sun` | Stellar mass | REBOUND stellar mass |
+| `Rs` | `R_sun` | Stellar radius | transit geometry / collision radius |
+| `Rp` | `R_Jupiter` | Radius of the observed planet | transit geometry |
+
+These six values are enough to instantiate the current `ttv_sim` forward model on cached data.
+
+### Minimal in-memory `prop` shape
+
+The current simulation API expects `prop` as a list whose first entry is a dictionary containing at least the fields above:
+
+```python
+prop = [
+    {
+        "orbital_distance": 0.0347371,
+        "orbital_period": 2.4238039,
+        "Mp": 0.889836,
+        "Ms": 0.951,
+        "Rs": 0.927,
+        "Rp": 1.14,
+    }
+]
+```
+
+The full notebook-era workflow stores many more keys, but the reduced forward-simulation path only requires this subset.
+
+### Additional target metadata in the repository example
+
+The shipped `prop_data.csv` also includes many fields that are currently documented only informally, including:
+
+- target naming and catalog identifiers (`canonical_name`, `planet_name`, `star_name`, `catalog_name`)
+- stellar atmosphere and magnitude fields (`Teff`, `Vmag`, `Jmag`, `Hmag`, `Kmag`, `Tmag`)
+- orbital geometry (`inclination`, `eccentricity`, `omega`, `a/Rs`, `impact_parameter`)
+- transit observables (`transit_time`, `transit_duration`, `transit_depth`, `Rp/Rs`)
+- provenance fields (`*_ref`, `*_url`)
+
+That richer surface is still useful for the full notebook narrative, but it is intentionally outside the smallest validated quick-start contract.
 
 ## FITS products
 
 The cached FITS files under `mastDownload/TESS/` are the notebook's example TESS products. They remain part of the narrative workflow, but the reduced validation path intentionally avoids requiring a full transit-fitting rerun on them.
 
+At the moment, the rebuild documents these FITS inputs at the directory level rather than as a frozen schema. That is deliberate: Stage 3 aims to make the light-weight path clear first, while the full notebook-era fitting inputs are still being carved into a cleaner library boundary.
+
+## Workflow manifest shape
+
+The new configuration layer also introduces a JSON-serializable manifest shape via `cmat.workflow.workflow_manifest(...)`. The current object is:
+
+| Key | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `config` | object | yes | Serialized `RunConfig` |
+| `dependency_versions` | object | no | Version map for pinned runtime dependencies |
+| `notes` | object | no | Free-form run notes |
+
+The associated output-path helper lives in `OutputConfig.metadata_path`, which defaults to:
+
+```text
+artifacts/run_metadata.json
+```
+
+CMAT does not yet automatically persist this manifest for every run, but this is the intended shape for future reproducible run metadata.
+
 ## Stability note
 
-The current data-format coverage is intentionally pragmatic rather than exhaustive. The rebuild still needs a more formal schema description for the notebook-era FITS inputs and for any future saved run manifests.
+The current data-format coverage is intentionally pragmatic rather than exhaustive. The reduced CSV-driven path is now explicit, but the rebuild still needs a more formal schema description for the notebook-era FITS inputs and any future persisted result tables.

--- a/docs/DATA_FORMATS.md
+++ b/docs/DATA_FORMATS.md
@@ -1,0 +1,48 @@
+# Data Formats
+
+## Repository example data
+
+The bundled example data live under:
+
+```text
+data/WASP-44 b/
+```
+
+Current tracked files include:
+
+- `prop_data.csv` - cached target and system properties
+- `tc_data.csv` - cached transit-timing residuals and timing uncertainties
+- `mastDownload/TESS/.../*.fits` - cached TESS products used by the notebook workflow
+
+## `tc_data.csv`
+
+Current columns:
+
+- unnamed row index column
+- `ttv_mcmc` - inferred transit timing residual in seconds
+- `ttv_err` - timing uncertainty in seconds
+- `epochs` - integer transit epoch index
+
+This file is the lightest cached input for the reduced notebook smoke path.
+
+## `prop_data.csv`
+
+This cached table contains target and system metadata used by the notebook and forward simulation, including:
+
+- stellar radius and mass (`Rs`, `Ms`)
+- planetary radius and mass (`Rp`, `Mp`)
+- orbital period and semimajor axis (`orbital_period`, `orbital_distance`)
+- transit timing reference fields
+
+The reduced notebook smoke path currently reads:
+
+- `orbital_distance`
+- `orbital_period`
+- `Mp`
+- `Ms`
+- `Rs`
+- `Rp`
+
+## FITS products
+
+The cached FITS files under `mastDownload/TESS/` are the notebook's example TESS products. They remain part of the narrative workflow, but the reduced validation path intentionally avoids requiring a full transit-fitting rerun on them.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,48 @@
+# Installation
+
+## Install from PyPI
+
+```bash
+pip install CMAT-astro
+```
+
+## Install from a local checkout
+
+```bash
+git clone https://github.com/troyzx/CMAT.git
+cd CMAT
+python -m venv .venv
+source .venv/bin/activate
+pip install -e . -c constraints.txt
+```
+
+## Import surface
+
+CMAT is imported as:
+
+```python
+import cmat
+```
+
+Current top-level exports include:
+
+- `cmat.Fitlpf`
+- `cmat.ttv_sim`
+- `cmat.TargetConfig`
+- `cmat.FitControls`
+- `cmat.SimulationGrid`
+- `cmat.OutputConfig`
+- `cmat.RunConfig`
+
+## Environment notes
+
+- Use `constraints.txt` for the current validated dependency stack.
+- In restricted or sandboxed environments, set writable cache locations:
+
+```bash
+export MPLCONFIGDIR=/private/tmp/cmat-mplconfig
+export XDG_CACHE_HOME=/private/tmp/cmat-cache
+```
+
+- `cmat.Fitlpf` still depends on the constrained PyTransit / Numba / llvmlite stack.
+- `import cmat` and `cmat.ttv_sim` lazy-load cleanly without importing the full light-curve fitting stack.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -78,20 +78,24 @@ The notebook remains the full narrative example. It is heavier than the reduced 
 
 ## Synthetic example without remote data
 
-For a smaller self-contained forward-simulation example, run:
+For a smaller self-contained forward-simulation example, use either the script or the lightweight notebook:
 
 ```bash
 python examples/synthetic_ttv_quickstart.py
 ```
 
-This script:
+```bash
+jupyter notebook examples/synthetic_ttv_quickstart.ipynb
+```
 
-- defines a small synthetic TTV series
-- runs a reduced companion grid
-- computes reduced mass-threshold outputs
-- evaluates one reduced MEGNO point
+Both artifacts:
 
-It is intentionally smaller than `example.ipynb` and does not require remote TESS access.
+- define a small synthetic TTV series
+- run a reduced companion grid
+- compute reduced mass-threshold outputs
+- evaluate one reduced MEGNO point
+
+The script is the fastest non-notebook entry point. The notebook is the lightest interactive notebook path and is intentionally smaller than `example.ipynb`.
 
 ## What the quick start does not cover
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -20,6 +20,52 @@ This reduced path:
 - computes reduced mass-threshold outputs
 - runs one reduced MEGNO point
 
+## Minimal cached-data example
+
+The reduced smoke path is built around the following minimal flow:
+
+```python
+import csv
+from pathlib import Path
+
+import numpy as np
+
+from cmat.ttv_sim import ttv_sim
+
+base = Path("data") / "WASP-44 b"
+
+with (base / "tc_data.csv").open() as handle:
+    ttv_rows = list(csv.DictReader(handle))
+with (base / "prop_data.csv").open() as handle:
+    prop_row = next(csv.DictReader(handle))
+
+epochs = np.array([int(row["epochs"]) for row in ttv_rows])
+ttv_mcmc = np.array([float(row["ttv_mcmc"]) for row in ttv_rows])
+ttv_err = np.array([float(row["ttv_err"]) for row in ttv_rows])
+prop = [
+    {
+        key: float(prop_row[key])
+        for key in ("orbital_distance", "orbital_period", "Mp", "Ms", "Rs", "Rp")
+    }
+]
+
+simulation = ttv_sim(
+    epochs=epochs,
+    ttv_mcmc=ttv_mcmc,
+    ttv_err=ttv_err,
+    rs=np.array([1.5]),
+    mp2s=np.array([10.0, 20.0]),
+    prop=prop,
+)
+simulation.ttv_results = [
+    simulation.calculate_rebound((1.5, 10.0)),
+    simulation.calculate_rebound((1.5, 20.0)),
+]
+chi2_limit, rms_limit = simulation.get_m_crit()
+```
+
+This is not a replacement for the full notebook. It is the smallest currently maintained example of the repository's forward-simulation half.
+
 ## Full narrative example
 
 For the current end-to-end astronomy workflow, run:
@@ -29,3 +75,13 @@ jupyter notebook example.ipynb
 ```
 
 The notebook remains the full narrative example. It is heavier than the reduced smoke path and still includes steps that are intentionally outside the smallest validation loop.
+
+## What the quick start does not cover
+
+The reduced path intentionally skips:
+
+- remote data download
+- global transit fitting
+- per-transit posterior sampling
+- full production TTV grids
+- full MEGNO sweeps

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -76,6 +76,23 @@ jupyter notebook example.ipynb
 
 The notebook remains the full narrative example. It is heavier than the reduced smoke path and still includes steps that are intentionally outside the smallest validation loop.
 
+## Synthetic example without remote data
+
+For a smaller self-contained forward-simulation example, run:
+
+```bash
+python examples/synthetic_ttv_quickstart.py
+```
+
+This script:
+
+- defines a small synthetic TTV series
+- runs a reduced companion grid
+- computes reduced mass-threshold outputs
+- evaluates one reduced MEGNO point
+
+It is intentionally smaller than `example.ipynb` and does not require remote TESS access.
+
 ## What the quick start does not cover
 
 The reduced path intentionally skips:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,31 @@
+# Quick Start
+
+## Fastest validation path
+
+The lightest validated example path currently uses the cached WASP-44 b data already stored in the repository.
+
+Run the reduced smoke test:
+
+```bash
+MPLCONFIGDIR=/private/tmp/cmat-mplconfig \
+XDG_CACHE_HOME=/private/tmp/cmat-cache \
+python -m unittest -v tests.test_notebook_smoke
+```
+
+This reduced path:
+
+- loads cached timing residuals from `data/WASP-44 b/tc_data.csv`
+- loads cached target properties from `data/WASP-44 b/prop_data.csv`
+- runs a reduced TTV forward-simulation slice
+- computes reduced mass-threshold outputs
+- runs one reduced MEGNO point
+
+## Full narrative example
+
+For the current end-to-end astronomy workflow, run:
+
+```bash
+jupyter notebook example.ipynb
+```
+
+The notebook remains the full narrative example. It is heavier than the reduced smoke path and still includes steps that are intentionally outside the smallest validation loop.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,5 @@ CMAT's user-facing documentation is split into focused entry points:
 - [Troubleshooting](TROUBLESHOOTING.md)
 
 The rebuild-specific engineering notes remain under [`docs/rebuild/`](rebuild/).
+
+For a small self-contained example script, see [`examples/synthetic_ttv_quickstart.py`](../examples/synthetic_ttv_quickstart.py).

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,4 +11,7 @@ CMAT's user-facing documentation is split into focused entry points:
 
 The rebuild-specific engineering notes remain under [`docs/rebuild/`](rebuild/).
 
-For a small self-contained example script, see [`examples/synthetic_ttv_quickstart.py`](../examples/synthetic_ttv_quickstart.py).
+For small self-contained examples, see:
+
+- [`examples/synthetic_ttv_quickstart.py`](../examples/synthetic_ttv_quickstart.py)
+- [`examples/synthetic_ttv_quickstart.ipynb`](../examples/synthetic_ttv_quickstart.ipynb)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+CMAT's user-facing documentation is split into focused entry points:
+
+- [Installation](INSTALLATION.md)
+- [Quick Start](QUICKSTART.md)
+- [Theory](THEORY.md)
+- [API Reference](API_REFERENCE.md)
+- [Data Formats](DATA_FORMATS.md)
+- [Troubleshooting](TROUBLESHOOTING.md)
+
+The rebuild-specific engineering notes remain under [`docs/rebuild/`](rebuild/).

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -34,3 +34,28 @@ Stage 2 validation now includes inject-recovery tests for these scoring paths. A
 ## Stability interpretation
 
 MEGNO is used as a dynamical-stability diagnostic alongside the TTV rejection surface. A low-mass candidate that matches the timing data may still be dynamically implausible if the corresponding MEGNO region is strongly unstable.
+
+## Interpreting outputs
+
+### Mass-limit curves
+
+The critical-mass output is best read as a rejection boundary, not a full posterior over all unseen companions. A lower critical mass at a given period ratio means the observed timing data rule out smaller companions there.
+
+### MEGNO maps
+
+MEGNO is a stability diagnostic, not a direct fit-quality score. In practice:
+
+- a region can be rejected by TTV mismatch even if it is dynamically stable
+- a region can look compatible in TTV space but still be dynamically unstable
+
+The most interesting regions are usually the ones that remain both observationally viable and dynamically plausible.
+
+### Observational caveats
+
+Current rejection boundaries still depend on:
+
+- the chosen simulation grid
+- the current `chi^2` and RMS scoring rules
+- the finite set of measured transit times and their uncertainties
+
+That is why the Stage 2 rebuild adds inject-recovery checks before any scoring backend is replaced.

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -1,0 +1,36 @@
+# Theory
+
+CMAT constrains hidden companion masses from transit timing variation (TTV) observations.
+
+## Workflow model
+
+1. Fit a transiting planet's light curve.
+2. Estimate per-transit center times and uncertainties.
+3. Convert those estimates into epoch-indexed TTV residuals.
+4. Simulate candidate two-planet systems with REBOUND.
+5. Compare simulated TTVs with observed residuals.
+6. Use MEGNO as an additional stability diagnostic.
+
+## Observation model
+
+The observed quantity is not the unseen companion directly. Instead, CMAT uses sparse timing residuals inferred from repeated transit events.
+
+## Forward model
+
+The current forward model is a grid of REBOUND N-body simulations over:
+
+- companion period ratios `P2/P1`
+- companion masses `M2`
+
+## Current scoring
+
+The current baseline scoring compares simulated and inferred TTVs using:
+
+- `chi^2` over epoch-aligned simulated residual windows
+- RMS amplitude screening
+
+Stage 2 validation now includes inject-recovery tests for these scoring paths. A more explicit probabilistic scoring model is deferred to Stage 4 of the rebuild.
+
+## Stability interpretation
+
+MEGNO is used as a dynamical-stability diagnostic alongside the TTV rejection surface. A low-mass candidate that matches the timing data may still be dynamically implausible if the corresponding MEGNO region is strongly unstable.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -10,6 +10,10 @@ pip install -e . -c constraints.txt
 
 The rebuild baseline depends on a specific PyTransit / Numba / llvmlite combination. The global environment may contain an incompatible pair even when `import cmat` itself succeeds.
 
+## Which Python versions are currently validated?
+
+The current CI baseline targets Python 3.10 and 3.11 with editable installation plus `constraints.txt`.
+
 ## Matplotlib or ArviZ cache errors
 
 Set writable cache locations:
@@ -19,13 +23,29 @@ export MPLCONFIGDIR=/private/tmp/cmat-mplconfig
 export XDG_CACHE_HOME=/private/tmp/cmat-cache
 ```
 
+Use the same environment variables when running the quick-start example or the reduced notebook smoke test.
+
 ## The full notebook is too heavy for a quick check
 
 Use the reduced smoke path instead:
 
 ```bash
+MPLCONFIGDIR=/private/tmp/cmat-mplconfig \
+XDG_CACHE_HOME=/private/tmp/cmat-cache \
 python -m unittest -v tests.test_notebook_smoke
 ```
+
+Or run the small synthetic example:
+
+```bash
+MPLCONFIGDIR=/private/tmp/cmat-mplconfig \
+XDG_CACHE_HOME=/private/tmp/cmat-cache \
+python examples/synthetic_ttv_quickstart.py
+```
+
+## Why do some reduced examples return empty mass-limit arrays?
+
+An empty critical-mass array means the tested reduced companion grid did not cross the current rejection threshold. In the smallest smoke examples, that is expected: the grid is intentionally tiny and conservative because it is meant to validate plumbing, not to reproduce the full production result surface.
 
 ## Why is the example still notebook-driven?
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,32 @@
+# Troubleshooting
+
+## `cmat.Fitlpf` import fails with Numba / llvmlite errors
+
+Use the constrained environment:
+
+```bash
+pip install -e . -c constraints.txt
+```
+
+The rebuild baseline depends on a specific PyTransit / Numba / llvmlite combination. The global environment may contain an incompatible pair even when `import cmat` itself succeeds.
+
+## Matplotlib or ArviZ cache errors
+
+Set writable cache locations:
+
+```bash
+export MPLCONFIGDIR=/private/tmp/cmat-mplconfig
+export XDG_CACHE_HOME=/private/tmp/cmat-cache
+```
+
+## The full notebook is too heavy for a quick check
+
+Use the reduced smoke path instead:
+
+```bash
+python -m unittest -v tests.test_notebook_smoke
+```
+
+## Why is the example still notebook-driven?
+
+The rebuild is staged. The current package now has typed configuration objects, workflow adapters, stronger validation, and a reduced smoke path, but the full transit-fitting workflow has not yet been decomposed into a complete reusable library pipeline.

--- a/examples/synthetic_ttv_quickstart.ipynb
+++ b/examples/synthetic_ttv_quickstart.ipynb
@@ -1,0 +1,124 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Synthetic CMAT quick-start\n",
+        "\n",
+        "This notebook is the lightest notebook-form CMAT example currently maintained in the rebuild. It mirrors `examples/synthetic_ttv_quickstart.py` and avoids remote TESS access, transit fitting, and the full production grid."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## What it covers\n",
+        "\n",
+        "- define a small synthetic TTV series\n",
+        "- run a reduced companion grid with `cmat.ttv_sim`\n",
+        "- compute reduced critical-mass outputs\n",
+        "- evaluate one reduced MEGNO point\n",
+        "\n",
+        "If your environment needs writable cache directories for Matplotlib-related imports, launch Jupyter with the same `MPLCONFIGDIR` and `XDG_CACHE_HOME` settings described in `docs/TROUBLESHOOTING.md`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "from cmat.ttv_sim import ttv_sim"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "epochs = np.array([0, 1, 2, 3])\n",
+        "ttv_mcmc = np.array([12.0, -8.0, 15.0, -10.0])\n",
+        "ttv_err = np.full(4, 5.0)\n",
+        "prop = [\n",
+        "    {\n",
+        "        \"orbital_distance\": 0.055,\n",
+        "        \"orbital_period\": 4.0,\n",
+        "        \"Mp\": 1.0,\n",
+        "        \"Ms\": 1.0,\n",
+        "        \"Rs\": 1.0,\n",
+        "        \"Rp\": 1.0,\n",
+        "    }\n",
+        "]\n",
+        "period_ratios = np.array([1.5, 2.0])\n",
+        "companion_masses = np.array([10.0, 20.0])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "simulation = ttv_sim(\n",
+        "    epochs=epochs,\n",
+        "    ttv_mcmc=ttv_mcmc,\n",
+        "    ttv_err=ttv_err,\n",
+        "    rs=period_ratios,\n",
+        "    mp2s=companion_masses,\n",
+        "    prop=prop,\n",
+        ")\n",
+        "\n",
+        "simulation.ttv_results = [\n",
+        "    simulation.calculate_rebound((period_ratio, companion_mass))\n",
+        "    for companion_mass in simulation.mp2s\n",
+        "    for period_ratio in simulation.rs\n",
+        "]\n",
+        "chi2_limit, rms_limit = simulation.get_m_crit()\n",
+        "\n",
+        "print(\"chi2 limits:\", chi2_limit.tolist())\n",
+        "print(\"rms limits:\", rms_limit.tolist())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "simulation.megno_dt = 0.02\n",
+        "simulation.megno_runtime = 50.0\n",
+        "megno = simulation.simulation_m((1.5, 10.0))\n",
+        "\n",
+        "print(\"sample megno:\", float(megno))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Interpreting the output\n",
+        "\n",
+        "- Empty reduced mass-limit arrays mean the tiny validation grid did not cross the current rejection threshold.\n",
+        "- The MEGNO value here is just a single reduced diagnostic point, not a full stability map.\n",
+        "- For the end-to-end astronomy workflow, use `example.ipynb` instead."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/examples/synthetic_ttv_quickstart.py
+++ b/examples/synthetic_ttv_quickstart.py
@@ -1,0 +1,56 @@
+"""Run a small synthetic CMAT forward-simulation example.
+
+This example avoids remote data access and transit fitting. It starts from a
+small synthetic TTV series and exercises the reduced forward-simulation path
+used in the Stage 3 quick-start documentation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cmat.ttv_sim import ttv_sim
+
+
+def main() -> None:
+    epochs = np.array([0, 1, 2, 3])
+    ttv_mcmc = np.array([12.0, -8.0, 15.0, -10.0])
+    ttv_err = np.full(4, 5.0)
+    prop = [
+        {
+            "orbital_distance": 0.055,
+            "orbital_period": 4.0,
+            "Mp": 1.0,
+            "Ms": 1.0,
+            "Rs": 1.0,
+            "Rp": 1.0,
+        }
+    ]
+
+    simulation = ttv_sim(
+        epochs=epochs,
+        ttv_mcmc=ttv_mcmc,
+        ttv_err=ttv_err,
+        rs=np.array([1.5, 2.0]),
+        mp2s=np.array([10.0, 20.0]),
+        prop=prop,
+    )
+    simulation.ttv_results = [
+        simulation.calculate_rebound((period_ratio, companion_mass))
+        for companion_mass in simulation.mp2s
+        for period_ratio in simulation.rs
+    ]
+    chi2_limit, rms_limit = simulation.get_m_crit()
+
+    simulation.megno_dt = 0.02
+    simulation.megno_runtime = 50.0
+    megno = simulation.simulation_m((1.5, 10.0))
+
+    print("Synthetic TTV quick-start")
+    print("chi2 limits:", chi2_limit.tolist())
+    print("rms limits:", rms_limit.tolist())
+    print("sample megno:", float(megno))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- split the user-facing documentation into installation, quick start, theory, API reference, data formats, and troubleshooting pages
- add a docs index under `docs/README.md` and wire the new docs surface into the repository README
- expand the quick-start surface around the reduced WASP-44 b validation path and the synthetic non-remote workflow
- add `examples/synthetic_ttv_quickstart.py` and `examples/synthetic_ttv_quickstart.ipynb` as lightweight Stage 3 examples
- document the current CSV input surfaces, typed configuration objects, workflow adapter contracts, and troubleshooting guidance

## Validation
- `git diff --check`
- JSON-load `examples/synthetic_ttv_quickstart.ipynb`
- execute the notebook code cells in the constrained rebuild environment

## Base Branch
This PR targets `dev/industry-rebuild` so the Stage 3 documentation and examples work can be reviewed independently from later inference and performance refactors.
