### PR TITLE
PR A: add compatibility naming aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ CMAT is imported as:
 import cmat
 ```
 
+For new code, prefer `cmat.TransitFitWorkflow` and `cmat.TTVSimulation`. The older `cmat.Fitlpf` and `cmat.ttv_sim` names remain available for compatibility.
+
 ## Example Notebook
 
 Run the included full notebook:

--- a/cmat/__init__.py
+++ b/cmat/__init__.py
@@ -2,7 +2,9 @@ name = "fitransit"
 
 __all__ = [
     "Fitlpf",
+    "TransitFitWorkflow",
     "ttv_sim",
+    "TTVSimulation",
     "TargetConfig",
     "FitControls",
     "SimulationGrid",
@@ -12,14 +14,20 @@ __all__ = [
 
 
 def __getattr__(attribute_name):
-    if attribute_name == "Fitlpf":
-        from .base import Fitlpf
+    if attribute_name in {"Fitlpf", "TransitFitWorkflow"}:
+        from .base import Fitlpf, TransitFitWorkflow
 
-        return Fitlpf
-    if attribute_name == "ttv_sim":
-        from .ttv_sim import ttv_sim
+        return {
+            "Fitlpf": Fitlpf,
+            "TransitFitWorkflow": TransitFitWorkflow,
+        }[attribute_name]
+    if attribute_name in {"ttv_sim", "TTVSimulation"}:
+        from .ttv_sim import TTVSimulation, ttv_sim
 
-        return ttv_sim
+        return {
+            "ttv_sim": ttv_sim,
+            "TTVSimulation": TTVSimulation,
+        }[attribute_name]
     if attribute_name in {
         "TargetConfig",
         "FitControls",

--- a/cmat/base.py
+++ b/cmat/base.py
@@ -612,3 +612,17 @@ class Fitlpf:
         plt.ylabel("residual (s)")
 
         return fig, ax
+
+    def plot_ttv_residuals(
+        self, plot_zero_epoch=False, set_epoch_zero=False, remove_baseline=True
+    ):
+        """Plot transit-timing residuals using the clearer public alias."""
+
+        return self.plot_ttv_re(
+            plot_zero_epoch=plot_zero_epoch,
+            set_epoch_zero=set_epoch_zero,
+            remove_baseline=remove_baseline,
+        )
+
+
+TransitFitWorkflow = Fitlpf

--- a/cmat/ttv_sim.py
+++ b/cmat/ttv_sim.py
@@ -185,6 +185,11 @@ class ttv_sim:
 
         return self.m_crit_chi2, self.m_crit_rms
 
+    def get_critical_masses(self):
+        """Return the first rejected companion masses for the current grid."""
+
+        return self.get_m_crit()
+
     def simulation_m(self, par):
         r, mp2 = par  # unpack parameters
         prop = self.prop
@@ -265,3 +270,6 @@ class ttv_sim:
         plt.xticks(new_ticks)
         plt.xlabel(r"$P_2/P_1$")
         plt.ylabel(r"$M_2$ [$M_j$]")
+
+
+TTVSimulation = ttv_sim

--- a/cmat/workflow.py
+++ b/cmat/workflow.py
@@ -15,7 +15,7 @@ from .config import RunConfig, TargetConfig
 
 
 def legacy_data_dir(target: TargetConfig) -> str:
-    """Return a data-root string compatible with the current `Fitlpf` API."""
+    """Return a data-root string compatible with the current fitting workflow API."""
 
     data_dir = Path(target.data_dir).as_posix().rstrip("/")
     if data_dir == "":
@@ -24,11 +24,11 @@ def legacy_data_dir(target: TargetConfig) -> str:
 
 
 def make_fit_lpf(target: TargetConfig):
-    """Create a `Fitlpf` instance from a target configuration."""
+    """Create a `TransitFitWorkflow` instance from a target configuration."""
 
-    from .base import Fitlpf
+    from .base import TransitFitWorkflow
 
-    return Fitlpf(target.planet_name, datadir=legacy_data_dir(target))
+    return TransitFitWorkflow(target.planet_name, datadir=legacy_data_dir(target))
 
 
 def make_ttv_simulation(
@@ -39,14 +39,14 @@ def make_ttv_simulation(
     ttv_err,
     prop,
 ):
-    """Create a `ttv_sim` instance from a run configuration and TTV data."""
+    """Create a `TTVSimulation` instance from a run configuration and TTV data."""
 
     if config.simulation is None:
         raise ValueError("config.simulation is required to create a TTV simulation")
 
-    from .ttv_sim import ttv_sim
+    from .ttv_sim import TTVSimulation
 
-    simulation = ttv_sim(
+    simulation = TTVSimulation(
         epochs=epochs,
         ttv_mcmc=ttv_mcmc,
         ttv_err=ttv_err,

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -8,8 +8,10 @@ CMAT's public surface is still evolving. The current practical entry points are:
 import cmat
 ```
 
-- `cmat.Fitlpf` - transit-fitting workflow object
-- `cmat.ttv_sim` - TTV and MEGNO forward-simulation workflow object
+- `cmat.TransitFitWorkflow` - preferred transit-fitting workflow name
+- `cmat.TTVSimulation` - preferred TTV and MEGNO forward-simulation workflow name
+- `cmat.Fitlpf` - legacy-compatible alias for `cmat.TransitFitWorkflow`
+- `cmat.ttv_sim` - legacy-compatible alias for `cmat.TTVSimulation`
 - `cmat.TargetConfig` - target metadata and data-root configuration
 - `cmat.FitControls` - fitting iteration and sampler controls
 - `cmat.SimulationGrid` - period-ratio, mass-grid, and MEGNO controls
@@ -141,9 +143,9 @@ The `cmat.workflow` module provides the current rebuild boundary around the lega
 
 | Function | Returns | Purpose |
 | --- | --- | --- |
-| `legacy_data_dir(target)` | `str` | Normalizes `TargetConfig.data_dir` to the trailing-slash string expected by `Fitlpf` |
-| `make_fit_lpf(target)` | `Fitlpf` | Builds a legacy transit-fitting object from a typed target config |
-| `make_ttv_simulation(config, *, epochs, ttv_mcmc, ttv_err, prop)` | `ttv_sim` | Builds a forward-simulation object from typed config plus observed TTV arrays |
+| `legacy_data_dir(target)` | `str` | Normalizes `TargetConfig.data_dir` to the trailing-slash string expected by the fitting workflow |
+| `make_fit_lpf(target)` | `TransitFitWorkflow` | Builds a transit-fitting object from a typed target config |
+| `make_ttv_simulation(config, *, epochs, ttv_mcmc, ttv_err, prop)` | `TTVSimulation` | Builds a forward-simulation object from typed config plus observed TTV arrays |
 | `workflow_manifest(config, *, dependency_versions=None, notes=None)` | `dict` | Builds a JSON-serializable run manifest |
 
 ### `make_ttv_simulation(...)` input contract
@@ -162,9 +164,9 @@ The `cmat.workflow` module provides the current rebuild boundary around the lega
 
 The adapter forwards:
 
-- `SimulationGrid.period_ratios` -> `ttv_sim.rs`
-- `SimulationGrid.companion_masses` -> `ttv_sim.mp2s`
-- `SimulationGrid.n_transit_simulations` -> `ttv_sim.N`
+- `SimulationGrid.period_ratios` -> `TTVSimulation.rs`
+- `SimulationGrid.companion_masses` -> `TTVSimulation.mp2s`
+- `SimulationGrid.n_transit_simulations` -> `TTVSimulation.N`
 - `SimulationGrid.megno_dt` / `megno_runtime` -> mutable MEGNO controls on the returned object
 
 ## Scoring helpers
@@ -178,16 +180,18 @@ The `cmat.scoring` module contains the current comparison helpers used by the fo
 | `get_chi2_v(...)` | Vectorized form of `get_chi2` used across simulation grids |
 | `get_rms_v(...)` | Vectorized form of `get_rms` used across simulation grids |
 
-## Legacy workflow classes
+## Workflow classes
 
-The classes below are still important, but they remain rebuild-era APIs rather than the preferred long-term boundary.
+The classes below are still rebuild-era APIs. The preferred public names are clearer aliases layered on top of the same current implementations.
 
-### `cmat.base.Fitlpf`
+### `cmat.TransitFitWorkflow`
+
+Legacy alias: `cmat.Fitlpf`
 
 Constructor:
 
 ```python
-Fitlpf(planet_name: str, datadir=None)
+TransitFitWorkflow(planet_name: str, datadir=None)
 ```
 
 Primary responsibilities:
@@ -204,16 +208,18 @@ Common call sequence in the current notebook-era workflow:
 3. `fit_singles()`
 4. `get_posterior_samples()`
 5. `calculate_ttv()`
-6. `plot_tcs()` / `plot_ttv_re()`
+6. `plot_tcs()` / `plot_ttv_residuals()` (`plot_ttv_re()` remains available as the legacy alias)
 
 Operational note: this is the most environment-sensitive surface because it depends on the PyTransit stack.
 
-### `cmat.ttv_sim.ttv_sim`
+### `cmat.TTVSimulation`
+
+Legacy alias: `cmat.ttv_sim`
 
 Constructor:
 
 ```python
-ttv_sim(epochs, ttv_mcmc, ttv_err, rs, mp2s, prop, N=80)
+TTVSimulation(epochs, ttv_mcmc, ttv_err, rs, mp2s, prop, N=80)
 ```
 
 Key constructor inputs:
@@ -232,13 +238,14 @@ Important attributes and methods:
 | --- | --- | --- |
 | `calculate_rebound((r, mp2))` | method | Simulate one REBOUND TTV series for a single grid point |
 | `get_ttv_rebound_all(number_of_thread)` | method | Run REBOUND across the full grid in parallel |
-| `get_m_crit()` | method | Compute first rejected companion masses for the current `chi^2` and RMS thresholds |
+| `get_critical_masses()` | method | Preferred public alias for the current mass-threshold extraction |
+| `get_m_crit()` | method | Legacy-compatible mass-threshold name |
 | `simulation_m((r, mp2))` | method | Run one MEGNO simulation |
 | `run_megno(number_of_threads)` | method | Run MEGNO across the full grid |
 | `plot_megno()` | method | Plot the MEGNO map |
 | `megno_dt` / `megno_runtime` | attributes | Controls for MEGNO timestep and integration runtime |
 
-`get_m_crit()` returns two arrays: the first rejected masses under the current `chi^2` threshold and the first rejected masses under the current RMS threshold. A period-ratio column only contributes an entry if the reduced grid actually crosses the corresponding rejection criterion.
+`get_critical_masses()` and `get_m_crit()` return the same pair of arrays: the first rejected masses under the current `chi^2` threshold and the first rejected masses under the current RMS threshold. A period-ratio column only contributes an entry if the reduced grid actually crosses the corresponding rejection criterion.
 
 ## Stability note
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -26,6 +26,8 @@ import cmat
 
 Current top-level exports include:
 
+- `cmat.TransitFitWorkflow` - preferred transit-fitting workflow name
+- `cmat.TTVSimulation` - preferred forward-simulation workflow name
 - `cmat.Fitlpf`
 - `cmat.ttv_sim`
 - `cmat.TargetConfig`
@@ -33,6 +35,8 @@ Current top-level exports include:
 - `cmat.SimulationGrid`
 - `cmat.OutputConfig`
 - `cmat.RunConfig`
+
+The preferred public names are `cmat.TransitFitWorkflow` and `cmat.TTVSimulation`. The older `cmat.Fitlpf` and `cmat.ttv_sim` names remain available as compatibility aliases.
 
 ## Environment notes
 
@@ -44,5 +48,5 @@ export MPLCONFIGDIR=/private/tmp/cmat-mplconfig
 export XDG_CACHE_HOME=/private/tmp/cmat-cache
 ```
 
-- `cmat.Fitlpf` still depends on the constrained PyTransit / Numba / llvmlite stack.
-- `import cmat` and `cmat.ttv_sim` lazy-load cleanly without importing the full light-curve fitting stack.
+- `cmat.TransitFitWorkflow` still depends on the constrained PyTransit / Numba / llvmlite stack.
+- `import cmat`, `cmat.TTVSimulation`, and `cmat.ttv_sim` lazy-load cleanly without importing the full light-curve fitting stack.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import numpy as np
 
-from cmat.ttv_sim import ttv_sim
+from cmat import TTVSimulation
 
 base = Path("data") / "WASP-44 b"
 
@@ -42,26 +42,28 @@ with (base / "prop_data.csv").open() as handle:
 epochs = np.array([int(row["epochs"]) for row in ttv_rows])
 ttv_mcmc = np.array([float(row["ttv_mcmc"]) for row in ttv_rows])
 ttv_err = np.array([float(row["ttv_err"]) for row in ttv_rows])
-prop = [
+target_properties = [
     {
         key: float(prop_row[key])
         for key in ("orbital_distance", "orbital_period", "Mp", "Ms", "Rs", "Rp")
     }
 ]
+period_ratios = np.array([1.5])
+companion_masses = np.array([10.0, 20.0])
 
-simulation = ttv_sim(
+simulation = TTVSimulation(
     epochs=epochs,
     ttv_mcmc=ttv_mcmc,
     ttv_err=ttv_err,
-    rs=np.array([1.5]),
-    mp2s=np.array([10.0, 20.0]),
-    prop=prop,
+    rs=period_ratios,
+    mp2s=companion_masses,
+    prop=target_properties,
 )
 simulation.ttv_results = [
     simulation.calculate_rebound((1.5, 10.0)),
     simulation.calculate_rebound((1.5, 20.0)),
 ]
-chi2_limit, rms_limit = simulation.get_m_crit()
+chi2_limit, rms_limit = simulation.get_critical_masses()
 ```
 
 This is not a replacement for the full notebook. It is the smallest currently maintained example of the repository's forward-simulation half.
@@ -87,6 +89,8 @@ python examples/synthetic_ttv_quickstart.py
 ```bash
 jupyter notebook examples/synthetic_ttv_quickstart.ipynb
 ```
+
+Both artifacts use the preferred `cmat.TTVSimulation` compatibility name while preserving the older `cmat.ttv_sim` path for existing code.
 
 Both artifacts:
 

--- a/examples/synthetic_ttv_quickstart.ipynb
+++ b/examples/synthetic_ttv_quickstart.ipynb
@@ -31,7 +31,7 @@
       "source": [
         "import numpy as np\n",
         "\n",
-        "from cmat.ttv_sim import ttv_sim"
+        "from cmat import TTVSimulation"
       ]
     },
     {
@@ -43,7 +43,7 @@
         "epochs = np.array([0, 1, 2, 3])\n",
         "ttv_mcmc = np.array([12.0, -8.0, 15.0, -10.0])\n",
         "ttv_err = np.full(4, 5.0)\n",
-        "prop = [\n",
+        "target_properties = [\n",
         "    {\n",
         "        \"orbital_distance\": 0.055,\n",
         "        \"orbital_period\": 4.0,\n",
@@ -63,13 +63,13 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "simulation = ttv_sim(\n",
+        "simulation = TTVSimulation(\n",
         "    epochs=epochs,\n",
         "    ttv_mcmc=ttv_mcmc,\n",
         "    ttv_err=ttv_err,\n",
         "    rs=period_ratios,\n",
         "    mp2s=companion_masses,\n",
-        "    prop=prop,\n",
+        "    prop=target_properties,\n",
         ")\n",
         "\n",
         "simulation.ttv_results = [\n",
@@ -77,7 +77,7 @@
         "    for companion_mass in simulation.mp2s\n",
         "    for period_ratio in simulation.rs\n",
         "]\n",
-        "chi2_limit, rms_limit = simulation.get_m_crit()\n",
+        "chi2_limit, rms_limit = simulation.get_critical_masses()\n",
         "\n",
         "print(\"chi2 limits:\", chi2_limit.tolist())\n",
         "print(\"rms limits:\", rms_limit.tolist())"

--- a/examples/synthetic_ttv_quickstart.py
+++ b/examples/synthetic_ttv_quickstart.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from cmat.ttv_sim import ttv_sim
+from cmat import TTVSimulation
 
 
 def main() -> None:
     epochs = np.array([0, 1, 2, 3])
     ttv_mcmc = np.array([12.0, -8.0, 15.0, -10.0])
     ttv_err = np.full(4, 5.0)
-    prop = [
+    target_properties = [
         {
             "orbital_distance": 0.055,
             "orbital_period": 4.0,
@@ -26,21 +26,23 @@ def main() -> None:
             "Rp": 1.0,
         }
     ]
+    period_ratios = np.array([1.5, 2.0])
+    companion_masses = np.array([10.0, 20.0])
 
-    simulation = ttv_sim(
+    simulation = TTVSimulation(
         epochs=epochs,
         ttv_mcmc=ttv_mcmc,
         ttv_err=ttv_err,
-        rs=np.array([1.5, 2.0]),
-        mp2s=np.array([10.0, 20.0]),
-        prop=prop,
+        rs=period_ratios,
+        mp2s=companion_masses,
+        prop=target_properties,
     )
     simulation.ttv_results = [
         simulation.calculate_rebound((period_ratio, companion_mass))
         for companion_mass in simulation.mp2s
         for period_ratio in simulation.rs
     ]
-    chi2_limit, rms_limit = simulation.get_m_crit()
+    chi2_limit, rms_limit = simulation.get_critical_masses()
 
     simulation.megno_dt = 0.02
     simulation.megno_runtime = 50.0

--- a/tests/test_package_import.py
+++ b/tests/test_package_import.py
@@ -10,7 +10,9 @@ class PackageImportTests(unittest.TestCase):
             cmat.__all__,
             [
                 "Fitlpf",
+                "TransitFitWorkflow",
                 "ttv_sim",
+                "TTVSimulation",
                 "TargetConfig",
                 "FitControls",
                 "SimulationGrid",
@@ -19,6 +21,8 @@ class PackageImportTests(unittest.TestCase):
             ],
         )
         self.assertTrue(callable(cmat.__getattr__("ttv_sim")))
+        self.assertTrue(callable(cmat.__getattr__("TTVSimulation")))
+        self.assertIs(cmat.__getattr__("TTVSimulation"), cmat.__getattr__("ttv_sim"))
 
     def test_top_level_config_export_is_available(self):
         cmat = importlib.import_module("cmat")
@@ -26,6 +30,17 @@ class PackageImportTests(unittest.TestCase):
         target = cmat.TargetConfig("WASP-44 b")
 
         self.assertEqual(target.planet_name, "WASP-44 b")
+
+    def test_legacy_and_preferred_fit_exports_both_resolve(self):
+        cmat = importlib.import_module("cmat")
+
+        self.assertTrue(callable(cmat.__getattr__("Fitlpf")))
+        self.assertTrue(callable(cmat.__getattr__("TransitFitWorkflow")))
+        self.assertIs(
+            cmat.__getattr__("TransitFitWorkflow"),
+            cmat.__getattr__("Fitlpf"),
+        )
+        self.assertTrue(hasattr(cmat.__getattr__("TransitFitWorkflow"), "plot_ttv_residuals"))
 
 
 if __name__ == "__main__":

--- a/tests/test_ttv_scoring.py
+++ b/tests/test_ttv_scoring.py
@@ -11,7 +11,7 @@ MPLCONFIGDIR = Path(tempfile.gettempdir()) / "cmat-test-mplconfig"
 MPLCONFIGDIR.mkdir(exist_ok=True)
 os.environ.setdefault("MPLCONFIGDIR", str(MPLCONFIGDIR))
 
-from cmat import scoring
+from cmat import TTVSimulation, scoring
 from cmat.ttv_sim import ttv_sim
 
 
@@ -174,6 +174,34 @@ class TtvScoringTests(unittest.TestCase):
 
         np.testing.assert_array_equal(chi2_limit, np.array([20.0, 20.0]))
         np.testing.assert_array_equal(rms_limit, np.array([20.0, 20.0]))
+
+    def test_preferred_ttvsimulation_alias_exposes_mass_threshold_method(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        simulation = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        simulation.ttv_results = [
+            np.array([0.0, 5.0, 5.0, 5.0]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+        ]
+
+        expected_chi2_limit, expected_rms_limit = simulation.get_m_crit()
+        chi2_limit, rms_limit = simulation.get_critical_masses()
+
+        np.testing.assert_array_equal(chi2_limit, expected_chi2_limit)
+        np.testing.assert_array_equal(rms_limit, expected_rms_limit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add preferred public aliases `cmat.TransitFitWorkflow` and `cmat.TTVSimulation` while preserving `cmat.Fitlpf` and `cmat.ttv_sim`
- add clearer method aliases `plot_ttv_residuals()` and `get_critical_masses()` without changing current behavior
- update `cmat.workflow`, docs, examples, and the synthetic notebook to prefer the clearer names
- extend tests so the new aliases and the legacy names both remain covered

## Validation
- `git diff --check`
- `MPLCONFIGDIR=/private/tmp/cmat-mplconfig XDG_CACHE_HOME=/private/tmp/cmat-cache /private/tmp/cmat-rebuild-env/bin/python -m unittest discover -s tests`
- execute the code cells in `examples/synthetic_ttv_quickstart.ipynb` in the constrained rebuild environment

## Base Branch
This PR targets `dev/industry-rebuild` after the Stage 3 docs/examples work merged, so naming cleanup stays isolated from the documentation split itself.
