### PR TITLE
Stage 5: simulator-adapter outputs, deployment example, and benchmarking notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,26 @@ CMAT focuses on one astronomy use case:
 
 This repository is research software. The code is useful as a worked scientific workflow and as a foundation for a future rebuild with stronger packaging, tests, reproducibility controls, and industry-facing examples.
 
+## Core Workflow as Inverse Modeling
+
+The astronomy vocabulary is specific, but the workflow shape is broader:
+
+| CMAT stage | Current astronomy implementation | General inverse-modeling role |
+| --- | --- | --- |
+| Observation extraction | Fit light curves and recover per-transit center times | Turn raw observations into a compact signal representation |
+| Uncertainty estimation | Propagate per-transit posterior uncertainty into `ttv_err` and timing residuals | Quantify how much ambiguity the downstream inference must absorb |
+| Forward simulation | Run REBOUND over companion-mass and period-ratio grids | Generate synthetic observables from candidate latent states |
+| Hypothesis rejection | Compare simulated TTVs with observed residuals using chi2/RMS or the experimental Bayesian mass-summary backend | Eliminate latent states that are inconsistent with the data |
+| Decision-surface generation | Summarize surviving regimes as mass-limit curves plus MEGNO stability structure | Produce an interpretable operating surface rather than a single point estimate |
+
+That framing is the main Stage 5 bridge: CMAT is still an astronomy codebase, but its workflow is also a concrete example of observation reduction, uncertainty-aware forward simulation, and constraint generation under a structured physical model.
+
 ## Repository Contents
 
 - `cmat/` - Python source code for TESS light-curve fitting, transit-center inference, TTV construction, REBOUND simulations, mass-limit estimation, and MEGNO mapping.
 - `data/WASP-44 b/` - example TESS and CSV data used by the included notebook.
 - `docs/` - user-facing installation, quick-start, theory, API, data-format, and troubleshooting guides.
-- `examples/` - small self-contained example scripts and notebooks that avoid the full notebook workflow.
+- `examples/` - small self-contained example scripts and notebooks, including both reduced astronomy workflows and a Stage 5 non-astronomy simulator-adapter example.
 - `example.ipynb` - end-to-end example notebook for WASP-44 b.
 - `requirements.txt` - runtime dependencies.
 - `LICENSE` - GNU General Public License v3.0.
@@ -35,6 +49,7 @@ This repository is research software. The code is useful as a worked scientific 
 - [Theory](docs/THEORY.md)
 - [API Reference](docs/API_REFERENCE.md)
 - [Data Formats](docs/DATA_FORMATS.md)
+- [Benchmarking](docs/BENCHMARKING.md)
 - [Troubleshooting](docs/TROUBLESHOOTING.md)
 - [Rebuild Notes](docs/rebuild/)
 
@@ -78,6 +93,22 @@ For a lighter interactive example that avoids remote data access and transit fit
 jupyter notebook examples/synthetic_ttv_quickstart.ipynb
 ```
 
+For the Stage 5 generic simulator-adapter path, run:
+
+```bash
+python examples/damped_oscillator_adapter.py
+```
+
+That example keeps the same inverse-modeling workflow shape but swaps the astronomy-specific simulator for a damped-oscillator forward model. It also writes a small portfolio bundle with a compact report, machine-readable table, summary JSON, and static figure under `artifacts/damped-oscillator-portfolio/`.
+
+For a deployment-style variant with stable run folders and persisted run metadata, run:
+
+```bash
+python examples/damped_oscillator_batch.py --run-name damped-oscillator-baseline
+```
+
+That batch-style example writes `run_metadata.json` plus a nested portfolio bundle under `artifacts/deployment/<run-name>/`, which makes repeated reruns easier to compare or archive.
+
 ## Workflow: TESS Light Curves to Upper Mass Constraints
 
 1. **Select a target.** Start with a known transiting planet and retrieve its system metadata, including stellar mass, planet mass, orbital period, radius, and reference transit time.
@@ -89,6 +120,18 @@ jupyter notebook examples/synthetic_ttv_quickstart.ipynb
 7. **Run forward simulations.** Use REBOUND to simulate each candidate two-planet system and generate synthetic TTVs.
 8. **Score candidate companions.** Compare simulated and inferred TTVs with `chi^2` and RMS criteria to estimate critical mass curves.
 9. **Assess dynamical stability.** Run MEGNO calculations over the same grid and compare stability structure with the inferred mass limits.
+
+## Transferable Workflow Pattern
+
+Read the same workflow in a more general way:
+
+1. **Extract observable structure** from raw measurements.
+2. **Quantify uncertainty** on that reduced observable.
+3. **Enumerate latent-state hypotheses** over a physically meaningful parameterization.
+4. **Run a forward simulator** to predict what each latent state would look like in observation space.
+5. **Reject inconsistent hypotheses** and summarize the remaining decision surface.
+
+The astronomy-specific pieces are the transit-fitting front end and the REBOUND/MEGNO simulator, but the surrounding workflow is a reusable inverse-modeling pattern for sparse, noisy measurement problems.
 
 ## Transferable Engineering Skills
 

--- a/cmat/workflow.py
+++ b/cmat/workflow.py
@@ -8,7 +8,10 @@ implementation.
 
 from __future__ import annotations
 
+import csv
+from dataclasses import dataclass
 import json
+from multiprocessing import get_context
 import os
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
@@ -16,11 +19,12 @@ from pathlib import Path
 import platform
 import subprocess
 import sys
-from typing import Any
+from typing import Any, Protocol, Sequence
 
 import numpy as np
+from tqdm.auto import tqdm
 
-from .config import RunConfig, TargetConfig
+from .config import ExecutionConfig, RunConfig, TargetConfig
 
 
 DEFAULT_PROVENANCE_DISTRIBUTIONS = (
@@ -42,6 +46,44 @@ DEFAULT_PROVENANCE_DISTRIBUTIONS = (
     "numba",
     "llvmlite",
 )
+
+
+@dataclass(frozen=True)
+class SimulatorAdapterRunResult:
+    """Structured result from a generic simulator-adapter evaluation."""
+
+    parameter_grid: tuple[dict[str, float], ...]
+    scores: np.ndarray
+    accepted: np.ndarray
+    summary: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "parameter_grid": [dict(parameters) for parameters in self.parameter_grid],
+            "scores": self.scores.tolist(),
+            "accepted": self.accepted.tolist(),
+            "summary": self.summary,
+        }
+
+
+class SimulatorAdapter(Protocol):
+    """Protocol for non-astronomy simulator adapters used by the Stage 5 workflow."""
+
+    def parameter_grid(self) -> Sequence[dict[str, float]]: ...
+
+    def simulate(self, parameters: dict[str, float]) -> Any: ...
+
+    def score(self, simulated_observable: Any) -> float: ...
+
+    def is_accepted(self, score: float) -> bool: ...
+
+    def summarize(
+        self,
+        *,
+        parameter_grid: tuple[dict[str, float], ...],
+        scores: np.ndarray,
+        accepted: np.ndarray,
+    ) -> dict[str, Any]: ...
 
 
 def legacy_data_dir(target: TargetConfig) -> str:
@@ -101,6 +143,351 @@ def make_ttv_simulation(
     simulation.start_method = config.execution.start_method
     simulation.show_progress = config.execution.show_progress
     return simulation
+
+
+def _normalize_parameter_grid(
+    parameter_grid: Sequence[dict[str, float]],
+) -> tuple[dict[str, float], ...]:
+    normalized: list[dict[str, float]] = []
+    for parameters in parameter_grid:
+        if not isinstance(parameters, dict) or not parameters:
+            raise ValueError("adapter parameter_grid() must return non-empty dictionaries")
+        normalized_parameters: dict[str, float] = {}
+        for name, value in parameters.items():
+            if not isinstance(name, str):
+                raise TypeError("adapter parameter names must be strings")
+            name = name.strip()
+            if not name:
+                raise ValueError("adapter parameter names must not be empty")
+            value = float(value)
+            if not np.isfinite(value):
+                raise ValueError("adapter parameter values must be finite")
+            normalized_parameters[name] = value
+        normalized.append(dict(sorted(normalized_parameters.items())))
+    if not normalized:
+        raise ValueError("adapter parameter_grid() must not be empty")
+    return tuple(normalized)
+
+
+def _adapter_score_task(task: tuple[SimulatorAdapter, dict[str, float]]) -> float:
+    adapter, parameters = task
+    return float(adapter.score(adapter.simulate(parameters)))
+
+
+def run_simulator_adapter(
+    adapter: SimulatorAdapter,
+    *,
+    execution: ExecutionConfig | None = None,
+) -> SimulatorAdapterRunResult:
+    """Run a generic simulator adapter over its latent-state grid.
+
+    This Stage 5 helper keeps the astronomy-specific TTV path intact while
+    exposing the same inverse-modeling workflow shape for other physical
+    simulation domains.
+    """
+
+    if execution is None:
+        execution = ExecutionConfig(show_progress=False)
+    if not isinstance(execution, ExecutionConfig):
+        raise TypeError("execution must be an ExecutionConfig or None")
+
+    parameter_grid = _normalize_parameter_grid(adapter.parameter_grid())
+    tasks = [(adapter, parameters) for parameters in parameter_grid]
+
+    if execution.worker_count == 1:
+        iterator = map(_adapter_score_task, tasks)
+    else:
+        context = get_context(execution.start_method)
+        pool = context.Pool(execution.worker_count)
+        try:
+            iterator = pool.imap(_adapter_score_task, tasks)
+            if execution.show_progress:
+                iterator = tqdm(iterator, total=len(tasks))
+            scores = np.asarray(list(iterator), dtype=float)
+        finally:
+            pool.close()
+            pool.join()
+        if not np.all(np.isfinite(scores)):
+            raise ValueError("adapter scores must be finite")
+        accepted = np.asarray(
+            [bool(adapter.is_accepted(float(score))) for score in scores],
+            dtype=bool,
+        )
+        return SimulatorAdapterRunResult(
+            parameter_grid=parameter_grid,
+            scores=scores,
+            accepted=accepted,
+            summary=adapter.summarize(
+                parameter_grid=parameter_grid,
+                scores=scores.copy(),
+                accepted=accepted.copy(),
+            ),
+        )
+
+    if execution.show_progress:
+        iterator = tqdm(iterator, total=len(tasks))
+    scores = np.asarray(list(iterator), dtype=float)
+    if not np.all(np.isfinite(scores)):
+        raise ValueError("adapter scores must be finite")
+    accepted = np.asarray(
+        [bool(adapter.is_accepted(float(score))) for score in scores],
+        dtype=bool,
+    )
+    return SimulatorAdapterRunResult(
+        parameter_grid=parameter_grid,
+        scores=scores,
+        accepted=accepted,
+        summary=adapter.summarize(
+            parameter_grid=parameter_grid,
+            scores=scores.copy(),
+            accepted=accepted.copy(),
+        ),
+    )
+
+
+def _write_simulator_adapter_figure(
+    result: SimulatorAdapterRunResult,
+    *,
+    figures_dir: Path,
+    parameter_names: tuple[str, ...],
+    title: str,
+) -> Path | None:
+    if len(parameter_names) not in (1, 2):
+        return None
+
+    from matplotlib import pyplot as plt
+
+    figures_dir.mkdir(parents=True, exist_ok=True)
+    figure_path = figures_dir / "score_surface.png"
+    fig, ax = plt.subplots(figsize=(7, 5))
+
+    if len(parameter_names) == 1:
+        x_name = parameter_names[0]
+        x = np.asarray([parameters[x_name] for parameters in result.parameter_grid], dtype=float)
+        ax.plot(x, result.scores, marker="o", color="tab:blue")
+        accepted_mask = np.asarray(result.accepted, dtype=bool)
+        if np.any(accepted_mask):
+            ax.scatter(
+                x[accepted_mask],
+                result.scores[accepted_mask],
+                color="tab:green",
+                label="accepted",
+                zorder=3,
+            )
+        ax.set_xlabel(x_name)
+        ax.set_ylabel("score")
+    else:
+        x_name, y_name = parameter_names
+        x = np.asarray([parameters[x_name] for parameters in result.parameter_grid], dtype=float)
+        y = np.asarray([parameters[y_name] for parameters in result.parameter_grid], dtype=float)
+        scatter = ax.scatter(x, y, c=result.scores, cmap="viridis", s=120)
+        accepted_mask = np.asarray(result.accepted, dtype=bool)
+        if np.any(accepted_mask):
+            ax.scatter(
+                x[accepted_mask],
+                y[accepted_mask],
+                facecolors="none",
+                edgecolors="white",
+                linewidths=2.0,
+                s=180,
+                label="accepted",
+            )
+        ax.set_xlabel(x_name)
+        ax.set_ylabel(y_name)
+        colorbar = fig.colorbar(scatter, ax=ax)
+        colorbar.set_label("score")
+
+    ax.set_title(title)
+    ax.grid(alpha=0.25)
+    if np.any(result.accepted):
+        ax.legend(loc="best")
+    fig.tight_layout()
+    fig.savefig(figure_path, dpi=150)
+    plt.close(fig)
+    return figure_path
+
+
+def write_simulator_adapter_portfolio(
+    result: SimulatorAdapterRunResult,
+    *,
+    output_dir: str | Path,
+    title: str = "Simulator adapter portfolio output",
+) -> dict[str, Path]:
+    """Write report, table, and figure artifacts for a simulator-adapter run."""
+
+    if not isinstance(result, SimulatorAdapterRunResult):
+        raise TypeError("result must be a SimulatorAdapterRunResult")
+
+    output_dir = Path(output_dir)
+    tables_dir = output_dir / "tables"
+    figures_dir = output_dir / "figures"
+    report_path = output_dir / "report.md"
+    summary_path = output_dir / "summary.json"
+    table_path = tables_dir / "grid_scores.csv"
+
+    parameter_names = tuple(result.parameter_grid[0].keys()) if result.parameter_grid else ()
+    candidate_count = len(result.parameter_grid)
+    accepted_count = int(np.sum(result.accepted))
+    best_index = int(np.argmin(result.scores))
+    best_parameters = result.parameter_grid[best_index]
+    best_score = float(result.scores[best_index])
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    figures_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_payload = {
+        "title": title,
+        "parameter_names": list(parameter_names),
+        "candidate_count": candidate_count,
+        "accepted_count": accepted_count,
+        "best_parameters": best_parameters,
+        "best_score": best_score,
+        "result_summary": result.summary,
+    }
+    summary_path.write_text(
+        json.dumps(summary_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with table_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[*parameter_names, "score", "accepted"],
+        )
+        writer.writeheader()
+        for parameters, score, accepted in zip(
+            result.parameter_grid,
+            result.scores,
+            result.accepted,
+            strict=True,
+        ):
+            row = dict(parameters)
+            row["score"] = float(score)
+            row["accepted"] = bool(accepted)
+            writer.writerow(row)
+
+    report_path.write_text(
+        "\n".join(
+            [
+                f"# {title}",
+                "",
+                "## Summary",
+                "",
+                f"- candidates evaluated: {candidate_count}",
+                f"- accepted candidates: {accepted_count}",
+                f"- best score: {best_score:.6f}",
+                f"- best parameters: `{json.dumps(best_parameters, sort_keys=True)}`",
+                "",
+                "## Artifact paths",
+                "",
+                f"- summary JSON: `{summary_path}`",
+                f"- score table CSV: `{table_path}`",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    paths = {
+        "report": report_path,
+        "summary": summary_path,
+        "table": table_path,
+    }
+    figure_path = _write_simulator_adapter_figure(
+        result,
+        figures_dir=figures_dir,
+        parameter_names=parameter_names,
+        title=title,
+    )
+    if figure_path is not None:
+        report_path.write_text(
+            report_path.read_text(encoding="utf-8")
+            + f"- score figure: `{figure_path}`\n",
+            encoding="utf-8",
+        )
+        paths["figure"] = figure_path
+    return paths
+
+
+def simulator_adapter_manifest(
+    result: SimulatorAdapterRunResult,
+    *,
+    adapter_name: str,
+    execution: ExecutionConfig | None = None,
+    dependency_versions: dict[str, str] | None = None,
+    notes: dict[str, Any] | None = None,
+    code_version: dict[str, Any] | None = None,
+    runtime: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-serializable manifest for a simulator-adapter run."""
+
+    if not isinstance(result, SimulatorAdapterRunResult):
+        raise TypeError("result must be a SimulatorAdapterRunResult")
+    if not isinstance(adapter_name, str) or not adapter_name.strip():
+        raise ValueError("adapter_name must be a non-empty string")
+    if execution is not None and not isinstance(execution, ExecutionConfig):
+        raise TypeError("execution must be an ExecutionConfig or None")
+
+    parameter_names = tuple(result.parameter_grid[0].keys()) if result.parameter_grid else ()
+    accepted_count = int(np.sum(result.accepted))
+    best_index = int(np.argmin(result.scores))
+
+    manifest: dict[str, Any] = {
+        "adapter_name": adapter_name.strip(),
+        "parameter_names": list(parameter_names),
+        "candidate_count": len(result.parameter_grid),
+        "accepted_count": accepted_count,
+        "best_parameters": result.parameter_grid[best_index],
+        "best_score": float(result.scores[best_index]),
+        "result_summary": result.summary,
+    }
+    if execution is not None:
+        manifest["execution"] = execution.to_dict()
+    if dependency_versions is not None:
+        manifest["dependency_versions"] = dict(sorted(dependency_versions.items()))
+    if code_version is not None:
+        manifest["code_version"] = code_version
+    if runtime is not None:
+        manifest["runtime"] = runtime
+    if notes is not None:
+        manifest["notes"] = notes
+    return manifest
+
+
+def write_simulator_adapter_manifest(
+    result: SimulatorAdapterRunResult,
+    *,
+    adapter_name: str,
+    metadata_path: str | Path,
+    execution: ExecutionConfig | None = None,
+    dependency_versions: dict[str, str] | None = None,
+    notes: dict[str, Any] | None = None,
+    code_version: dict[str, Any] | None = None,
+    runtime: dict[str, Any] | None = None,
+) -> Path:
+    """Persist a simulator-adapter run manifest for deployment-style examples."""
+
+    metadata_path = Path(metadata_path)
+    manifest = simulator_adapter_manifest(
+        result,
+        adapter_name=adapter_name,
+        execution=execution,
+        dependency_versions=(
+            provenance_dependency_versions()
+            if dependency_versions is None
+            else dependency_versions
+        ),
+        notes=notes,
+        code_version=provenance_code_version() if code_version is None else code_version,
+        runtime=provenance_runtime() if runtime is None else runtime,
+    )
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return metadata_path
 
 
 def workflow_manifest(

--- a/cmat/workflow.py
+++ b/cmat/workflow.py
@@ -48,6 +48,9 @@ DEFAULT_PROVENANCE_DISTRIBUTIONS = (
 )
 
 
+_SIMULATOR_ADAPTER_WORKER: SimulatorAdapter | None = None
+
+
 @dataclass(frozen=True)
 class SimulatorAdapterRunResult:
     """Structured result from a generic simulator-adapter evaluation."""
@@ -149,7 +152,8 @@ def _normalize_parameter_grid(
     parameter_grid: Sequence[dict[str, float]],
 ) -> tuple[dict[str, float], ...]:
     normalized: list[dict[str, float]] = []
-    for parameters in parameter_grid:
+    expected_keys: tuple[str, ...] | None = None
+    for index, parameters in enumerate(parameter_grid):
         if not isinstance(parameters, dict) or not parameters:
             raise ValueError("adapter parameter_grid() must return non-empty dictionaries")
         normalized_parameters: dict[str, float] = {}
@@ -163,15 +167,69 @@ def _normalize_parameter_grid(
             if not np.isfinite(value):
                 raise ValueError("adapter parameter values must be finite")
             normalized_parameters[name] = value
-        normalized.append(dict(sorted(normalized_parameters.items())))
+        normalized_parameters = dict(sorted(normalized_parameters.items()))
+        normalized_keys = tuple(normalized_parameters.keys())
+        if expected_keys is None:
+            expected_keys = normalized_keys
+        elif normalized_keys != expected_keys:
+            raise ValueError(
+                "adapter parameter_grid() entries must share the same parameter keys; "
+                f"expected keys {list(expected_keys)} but entry {index} had keys {list(normalized_keys)}"
+            )
+        normalized.append(normalized_parameters)
     if not normalized:
         raise ValueError("adapter parameter_grid() must not be empty")
     return tuple(normalized)
 
 
-def _adapter_score_task(task: tuple[SimulatorAdapter, dict[str, float]]) -> float:
-    adapter, parameters = task
+def _set_simulator_adapter_worker(adapter: SimulatorAdapter) -> None:
+    global _SIMULATOR_ADAPTER_WORKER
+    _SIMULATOR_ADAPTER_WORKER = adapter
+
+
+def _adapter_score_task(parameters: dict[str, float]) -> float:
+    adapter = _SIMULATOR_ADAPTER_WORKER
+    if adapter is None:
+        raise RuntimeError("simulator adapter worker is not initialized")
     return float(adapter.score(adapter.simulate(parameters)))
+
+
+def _score_adapter(adapter: SimulatorAdapter, parameters: dict[str, float]) -> float:
+    return float(adapter.score(adapter.simulate(parameters)))
+
+
+def _validate_simulator_adapter_result(
+    result: SimulatorAdapterRunResult,
+) -> SimulatorAdapterRunResult:
+    if not isinstance(result, SimulatorAdapterRunResult):
+        raise TypeError("result must be a SimulatorAdapterRunResult")
+    if not result.parameter_grid:
+        raise ValueError("result.parameter_grid must not be empty")
+
+    scores = np.asarray(result.scores)
+    accepted = np.asarray(result.accepted)
+    if scores.ndim != 1:
+        raise ValueError("result.scores must be a 1-D array")
+    if accepted.ndim != 1:
+        raise ValueError("result.accepted must be a 1-D array")
+
+    candidate_count = len(result.parameter_grid)
+    if len(scores) != candidate_count or len(accepted) != candidate_count:
+        raise ValueError(
+            "result.scores, result.accepted, and result.parameter_grid must have matching lengths"
+        )
+    if not np.all(np.isfinite(scores)):
+        raise ValueError("result.scores must contain only finite values")
+
+    expected_keys = tuple(result.parameter_grid[0].keys())
+    for index, parameters in enumerate(result.parameter_grid[1:], start=1):
+        keys = tuple(parameters.keys())
+        if keys != expected_keys:
+            raise ValueError(
+                "result.parameter_grid entries must share the same parameter keys; "
+                f"expected keys {list(expected_keys)} but entry {index} had keys {list(keys)}"
+            )
+    return result
 
 
 def run_simulator_adapter(
@@ -192,21 +250,19 @@ def run_simulator_adapter(
         raise TypeError("execution must be an ExecutionConfig or None")
 
     parameter_grid = _normalize_parameter_grid(adapter.parameter_grid())
-    tasks = [(adapter, parameters) for parameters in parameter_grid]
-
     if execution.worker_count == 1:
-        iterator = map(_adapter_score_task, tasks)
+        iterator = (_score_adapter(adapter, parameters) for parameters in parameter_grid)
     else:
         context = get_context(execution.start_method)
-        pool = context.Pool(execution.worker_count)
-        try:
-            iterator = pool.imap(_adapter_score_task, tasks)
+        with context.Pool(
+            execution.worker_count,
+            initializer=_set_simulator_adapter_worker,
+            initargs=(adapter,),
+        ) as pool:
+            iterator = pool.imap(_adapter_score_task, parameter_grid)
             if execution.show_progress:
-                iterator = tqdm(iterator, total=len(tasks))
+                iterator = tqdm(iterator, total=len(parameter_grid))
             scores = np.asarray(list(iterator), dtype=float)
-        finally:
-            pool.close()
-            pool.join()
         if not np.all(np.isfinite(scores)):
             raise ValueError("adapter scores must be finite")
         accepted = np.asarray(
@@ -225,7 +281,7 @@ def run_simulator_adapter(
         )
 
     if execution.show_progress:
-        iterator = tqdm(iterator, total=len(tasks))
+        iterator = tqdm(iterator, total=len(parameter_grid))
     scores = np.asarray(list(iterator), dtype=float)
     if not np.all(np.isfinite(scores)):
         raise ValueError("adapter scores must be finite")
@@ -315,8 +371,7 @@ def write_simulator_adapter_portfolio(
 ) -> dict[str, Path]:
     """Write report, table, and figure artifacts for a simulator-adapter run."""
 
-    if not isinstance(result, SimulatorAdapterRunResult):
-        raise TypeError("result must be a SimulatorAdapterRunResult")
+    result = _validate_simulator_adapter_result(result)
 
     output_dir = Path(output_dir)
     tables_dir = output_dir / "tables"
@@ -422,8 +477,7 @@ def simulator_adapter_manifest(
 ) -> dict[str, Any]:
     """Build a JSON-serializable manifest for a simulator-adapter run."""
 
-    if not isinstance(result, SimulatorAdapterRunResult):
-        raise TypeError("result must be a SimulatorAdapterRunResult")
+    result = _validate_simulator_adapter_result(result)
     if not isinstance(adapter_name, str) or not adapter_name.strip():
         raise ValueError("adapter_name must be a non-empty string")
     if execution is not None and not isinstance(execution, ExecutionConfig):

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -202,6 +202,10 @@ The `cmat.workflow` module provides the current rebuild boundary around the lega
 | `legacy_data_dir(target)` | `str` | Normalizes `TargetConfig.data_dir` to the trailing-slash string expected by the fitting workflow |
 | `make_fit_lpf(target)` | `TransitFitWorkflow` | Builds a transit-fitting object from a typed target config |
 | `make_ttv_simulation(config, *, epochs, ttv_mcmc, ttv_err, prop, scoring_backend=None)` | `TTVSimulation` | Builds a forward-simulation object from typed config plus observed TTV arrays and selects the configured default scorer |
+| `run_simulator_adapter(adapter, *, execution=None)` | `SimulatorAdapterRunResult` | Runs a generic Stage 5 simulator adapter over its latent-state grid |
+| `write_simulator_adapter_portfolio(result, *, output_dir, title=...)` | `dict[str, Path]` | Writes report, table, and figure artifacts for a simulator-adapter run |
+| `simulator_adapter_manifest(result, *, adapter_name, execution=None, dependency_versions=None, notes=None, code_version=None, runtime=None)` | `dict` | Builds a JSON-serializable manifest for a simulator-adapter run |
+| `write_simulator_adapter_manifest(result, *, adapter_name, metadata_path, execution=None, dependency_versions=None, notes=None, code_version=None, runtime=None)` | `Path` | Writes a simulator-adapter manifest for deployment-style artifacts |
 | `workflow_manifest(config, *, dependency_versions=None, notes=None, scoring_summary=None, code_version=None, runtime=None)` | `dict` | Builds a JSON-serializable run manifest |
 | `write_workflow_manifest(config, *, dependency_versions=None, notes=None, scoring_summary=None, code_version=None, runtime=None, metadata_path=None)` | `Path` | Writes a provenance manifest to `OutputConfig.metadata_path` |
 | `write_ttv_grid_cache(config, *, epochs, ttv_mcmc, ttv_err, ttv_results, cache_path=None)` | `Path` | Writes a reusable compressed TTV-grid cache |
@@ -238,6 +242,44 @@ The adapter forwards:
 `workflow_manifest(...)` also accepts `scoring_summary`, which can be either a plain dict or a `MassThresholds` object. `write_workflow_manifest(...)` builds on that shape and persists `code_version`, installed `dependency_versions`, runtime metadata, and the serialized scoring summary to `OutputConfig.metadata_path`.
 
 The cache helpers use `OutputConfig`'s derived cache paths so reduced runs and larger batch-style grids can reuse expensive intermediate products explicitly instead of recomputing them. TTV and MEGNO grids are stored as compressed `.npz` bundles keyed by the configured mass/ratio grid, while retained Bayesian posterior samples are stored as a focused JSON subset of the Bayesian scoring summary.
+
+### `run_simulator_adapter(...)` contract
+
+`run_simulator_adapter(...)` is the Stage 5 generic workflow bridge. It leaves the astronomy-specific TTV implementation untouched, but lets another physical system expose the same high-level shape through a small adapter object.
+
+The adapter is expected to provide:
+
+- `parameter_grid()` -> sequence of non-empty `{name: float}` dictionaries
+- `simulate(parameters)` -> one simulated observable for that latent-state point
+- `score(simulated_observable)` -> finite mismatch or utility score
+- `is_accepted(score)` -> boolean acceptance decision
+- `summarize(parameter_grid=..., scores=..., accepted=...)` -> JSON-friendly summary dict
+
+`run_simulator_adapter(...)` returns a `SimulatorAdapterRunResult` with the normalized parameter grid, per-point scores, acceptance mask, and adapter summary. It accepts an `ExecutionConfig` so generic examples can reuse the same worker-count / start-method / progress controls as the rebuilt astronomy path.
+
+### `write_simulator_adapter_portfolio(...)` contract
+
+`write_simulator_adapter_portfolio(...)` turns a `SimulatorAdapterRunResult` into a small portfolio bundle:
+
+- `report.md` - compact human-readable summary
+- `summary.json` - machine-readable headline metadata
+- `tables/grid_scores.csv` - one row per latent-state point
+- `figures/score_surface.png` - static score figure for one- or two-parameter grids
+
+This is the current Stage 5 path for producing portfolio-style artifacts without changing the legacy astronomy notebook workflow.
+
+### `simulator_adapter_manifest(...)` contract
+
+`simulator_adapter_manifest(...)` summarizes a generic adapter run in a JSON-friendly shape suitable for persisted metadata:
+
+- adapter name
+- parameter names and candidate counts
+- accepted count
+- best-scoring parameter point
+- adapter summary payload
+- optional execution, provenance, and freeform notes
+
+`write_simulator_adapter_manifest(...)` persists the same structure to a chosen `run_metadata.json` path, filling in dependency versions, git metadata, and runtime context by default. This is the current Stage 5 deployment-oriented companion to `write_simulator_adapter_portfolio(...)`.
 
 ## Scoring helpers
 

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -1,0 +1,109 @@
+# Benchmarking
+
+CMAT now has two practical benchmark surfaces:
+
+1. the astronomy-specific reduced regression benchmark in [`docs/rebuild/WASP44_REDUCED_BENCHMARK.md`](rebuild/WASP44_REDUCED_BENCHMARK.md), which protects scientific behavior without requiring a production-scale rerun;
+2. the Stage 5 simulator-adapter examples, which are small enough to use for runtime, multiprocessing, and artifact-layout comparisons.
+
+This guide focuses on the second surface: how to record runtime, grid size, multiprocessing strategy, and memory use in a way that stays comparable across reruns.
+
+## What to record
+
+For any benchmark note, capture the same small set of facts:
+
+- workflow surface: astronomy TTV path, generic simulator adapter, or deployment-style batch example;
+- grid definition: candidate count plus the parameter ranges that produced it;
+- execution controls: `worker_count`, `start_method`, and whether progress output was enabled;
+- artifact path: where `run_metadata.json`, portfolio outputs, or caches were written;
+- environment: Python version, dependency versions, git commit, and any cache-related environment variables.
+
+The deployment-style adapter example already persists most of that metadata to `run_metadata.json`.
+
+## Grid size
+
+Benchmark notes should always state how many latent-state points were evaluated.
+
+- astronomy TTV grid: `len(period_ratios) * len(companion_masses)`
+- simulator-adapter grid: `len(parameter_grid())`
+
+Without that number, raw wall-clock timings are hard to compare.
+
+## Runtime expectations
+
+Wall time is usually dominated by forward simulation, not by artifact writing.
+
+- `run_simulator_adapter(...)` scales with the number of candidate parameter points and the cost of each `simulate(...)` call;
+- portfolio and manifest writing are usually small fixed costs;
+- the astronomy path adds separate TTV and MEGNO passes, so benchmark notes should state which pass was timed.
+
+For very small grids, `worker_count=1` is often fastest because process startup can dominate the run.
+
+## Multiprocessing strategy
+
+`ExecutionConfig` exposes the main runtime knobs that should appear in every benchmark note:
+
+- `worker_count`: compare at least a serial baseline and one parallel run on the same grid;
+- `start_method`: use `"fork"` for simple local terminal runs on Unix-like systems, and `"spawn"` when you want cleaner worker initialization or notebook/CI-friendly behavior;
+- `show_progress`: disable it for batch logs so timing output stays clean.
+
+Do not compare worker counts across different grids or different start methods and call that a scaling result; keep one variable fixed at a time.
+
+## Memory notes
+
+Peak memory depends on both the workflow surface and how much intermediate state is retained.
+
+- simulator-adapter runs keep the normalized parameter grid, score array, acceptance mask, and summary payload in memory;
+- astronomy runs can also retain larger TTV, MEGNO, and posterior-sample products;
+- increasing `worker_count` can increase resident memory because each worker may hold simulator state or imported dependencies.
+
+For the astronomy path, persisted caches under `OutputConfig.cache_dir` trade disk usage for less recomputation. For the adapter path, portfolio and manifest artifacts are typically cheap relative to the simulation itself.
+
+## Recommended command pattern
+
+Use the constrained rebuild environment and writable cache directories:
+
+```bash
+export MPLCONFIGDIR=/private/tmp/cmat-mplconfig
+export XDG_CACHE_HOME=/private/tmp/cmat-cache
+```
+
+On macOS, use `/usr/bin/time -l` to capture wall time and peak resident set size while running the deployment-style adapter example:
+
+```bash
+/usr/bin/time -l /private/tmp/cmat-rebuild-env/bin/python \
+  examples/damped_oscillator_batch.py \
+  --run-name bench-w1 \
+  --worker-count 1
+
+/usr/bin/time -l /private/tmp/cmat-rebuild-env/bin/python \
+  examples/damped_oscillator_batch.py \
+  --run-name bench-w4 \
+  --worker-count 4 \
+  --start-method spawn
+```
+
+Those commands keep the model and artifact layout fixed while varying only the execution controls.
+
+## Benchmark note template
+
+Use a short record like this:
+
+```text
+surface: damped_oscillator_batch
+grid_size: 9 candidates
+worker_count: 4
+start_method: spawn
+show_progress: false
+artifacts: artifacts/deployment/bench-w4/
+wall_time_s: <measured>
+max_rss_bytes: <measured>
+notes: same adapter and run_name layout as serial baseline
+```
+
+## How to interpret results
+
+- If serial and parallel timings are similar, the grid is probably too small for multiprocessing to help.
+- If wall time drops but max RSS rises sharply, record that tradeoff explicitly instead of only reporting the faster run.
+- If repeated reruns vary significantly, compare the persisted `run_metadata.json` files first to confirm the grid and execution settings actually match.
+
+For scientific-regression benchmarking of the astronomy workflow, keep using the reduced WASP-44 benchmark document; this Stage 5 guide is meant to make runtime and deployment comparisons repeatable, not to replace the science-facing regression baseline.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -20,6 +20,14 @@ This reduced path:
 - computes reduced mass-threshold outputs
 - runs one reduced MEGNO point
 
+In Stage 5 terms, that same reduced path can be read as:
+
+1. **Observation extraction** - load the reduced timing residual series.
+2. **Uncertainty estimation** - carry the per-epoch timing uncertainties in `ttv_err`.
+3. **Forward simulation** - evaluate a small latent-state grid with REBOUND.
+4. **Hypothesis rejection** - compare simulated and observed timing structure.
+5. **Decision-surface generation** - summarize the result as reduced mass-limit and stability outputs.
+
 ## Minimal cached-data example
 
 The reduced smoke path is built around the following minimal flow:

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,19 @@ CMAT's user-facing documentation is split into focused entry points:
 - [Theory](THEORY.md)
 - [API Reference](API_REFERENCE.md)
 - [Data Formats](DATA_FORMATS.md)
+- [Benchmarking](BENCHMARKING.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
 
 The rebuild-specific engineering notes remain under [`docs/rebuild/`](rebuild/).
+
+The theory guide now covers both the astronomy-specific interpretation and the more general inverse-modeling pattern behind the workflow.
 
 For small self-contained examples, see:
 
 - [`examples/synthetic_ttv_quickstart.py`](../examples/synthetic_ttv_quickstart.py)
 - [`examples/synthetic_ttv_quickstart.ipynb`](../examples/synthetic_ttv_quickstart.ipynb)
 - [`examples/custom_scoring_backend.py`](../examples/custom_scoring_backend.py)
+- [`examples/damped_oscillator_adapter.py`](../examples/damped_oscillator_adapter.py)
+- [`examples/damped_oscillator_batch.py`](../examples/damped_oscillator_batch.py)
+
+The damped-oscillator adapter example is the current Stage 5 portfolio-output demo: it writes a report, score table, summary JSON, and static figure bundle. The batch variant adds a deployment-style run folder with `run_metadata.json` for reproducible reruns and artifact storage.

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -11,6 +11,21 @@ CMAT constrains hidden companion masses from transit timing variation (TTV) obse
 5. Compare simulated TTVs with observed residuals.
 6. Use MEGNO as an additional stability diagnostic.
 
+## Inverse-modeling framing
+
+The same workflow can be described without astronomy-specific jargon:
+
+| Workflow layer | CMAT currently does | Transferable role |
+| --- | --- | --- |
+| Observation extraction | Reduces light curves into per-transit timing measurements | Converts raw measurements into a compact observation vector |
+| Uncertainty estimation | Carries timing posteriors and `ttv_err` into downstream scoring | Makes data ambiguity explicit before simulation and rejection |
+| Latent-state parameterization | Uses companion mass and period ratio as the hidden-state grid | Defines the structured hypothesis space |
+| Forward simulation | Uses REBOUND to map each latent state to synthetic TTV observables | Predicts observation-space consequences of each hypothesis |
+| Hypothesis rejection | Scores mismatch with chi2/RMS or the experimental Bayesian summary backend | Removes inconsistent latent states |
+| Decision-surface generation | Produces mass-limit curves plus MEGNO stability context | Summarizes the viable vs rejected region of parameter space |
+
+This is the main industry-facing interpretation of CMAT: not “an astronomy notebook that happens to simulate planets”, but a compact example of uncertainty-aware inverse modeling with a physics-based forward simulator and an interpretable rejection surface.
+
 ## Observation model
 
 The observed quantity is not the unseen companion directly. Instead, CMAT uses sparse timing residuals inferred from repeated transit events.
@@ -30,6 +45,8 @@ The current baseline scoring compares simulated and inferred TTVs using:
 - RMS amplitude screening
 
 Stage 2 validation now includes inject-recovery tests for these scoring paths. A more explicit probabilistic scoring model is deferred to Stage 4 of the rebuild.
+
+Stage 4 now also includes an experimental Bayesian posterior mass-summary backend. Its primary role is to add explicit nuisance-parameter marginalization and evidence-backed mass summaries without changing the legacy chi2/RMS baseline contract.
 
 ## Stability interpretation
 

--- a/examples/damped_oscillator_adapter.py
+++ b/examples/damped_oscillator_adapter.py
@@ -1,0 +1,85 @@
+"""Demonstrate the Stage 5 simulator-adapter interface on a non-astronomy system.
+
+This example uses a damped oscillator as a tiny stand-in for a generic
+physics-based forward model. The adapter owns the observed signal, latent-state
+grid, scoring rule, and summary logic; `cmat.workflow.run_simulator_adapter(...)`
+runs that workflow shape without touching the astronomy-specific TTV stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from cmat.config import ExecutionConfig
+from cmat.workflow import run_simulator_adapter, write_simulator_adapter_portfolio
+
+
+class DampedOscillatorAdapter:
+    """Small deterministic adapter for a second-order damped oscillator."""
+
+    def __init__(self) -> None:
+        self.sample_times = np.linspace(0.0, 4.0, 25)
+        self.observed_displacement = self._displacement(stiffness=4.0, damping=0.6)
+        self.acceptance_threshold = 0.08
+
+    def parameter_grid(self):
+        return [
+            {"stiffness": stiffness, "damping": damping}
+            for stiffness in (3.0, 4.0, 5.0)
+            for damping in (0.3, 0.6, 0.9)
+        ]
+
+    def _displacement(self, *, stiffness: float, damping: float) -> np.ndarray:
+        angular_frequency = np.sqrt(max(stiffness - 0.25 * damping**2, 0.05))
+        return np.exp(-0.5 * damping * self.sample_times) * np.cos(
+            angular_frequency * self.sample_times
+        )
+
+    def simulate(self, parameters):
+        return self._displacement(
+            stiffness=parameters["stiffness"],
+            damping=parameters["damping"],
+        )
+
+    def score(self, simulated_observable) -> float:
+        residual = np.asarray(simulated_observable, dtype=float) - self.observed_displacement
+        return float(np.sqrt(np.mean(residual**2)))
+
+    def is_accepted(self, score: float) -> bool:
+        return score <= self.acceptance_threshold
+
+    def summarize(self, *, parameter_grid, scores, accepted):
+        best_index = int(np.argmin(scores))
+        return {
+            "acceptance_threshold": self.acceptance_threshold,
+            "accepted_count": int(np.sum(accepted)),
+            "best_parameters": parameter_grid[best_index],
+            "best_score": float(scores[best_index]),
+        }
+
+
+def main() -> None:
+    adapter = DampedOscillatorAdapter()
+    result = run_simulator_adapter(
+        adapter,
+        execution=ExecutionConfig(worker_count=1, show_progress=False),
+    )
+    portfolio_paths = write_simulator_adapter_portfolio(
+        result,
+        output_dir=Path("artifacts") / "damped-oscillator-portfolio",
+        title="Damped oscillator simulator-adapter demo",
+    )
+
+    print("Damped oscillator adapter example")
+    print("summary:", result.summary)
+    print("accepted:", result.accepted.tolist())
+    print(
+        "portfolio outputs:",
+        {name: str(path) for name, path in sorted(portfolio_paths.items())},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/damped_oscillator_batch.py
+++ b/examples/damped_oscillator_batch.py
@@ -1,0 +1,99 @@
+"""Batch-style deployment example for the Stage 5 simulator-adapter workflow.
+
+This example keeps the same damped-oscillator forward model as the smaller
+simulator-adapter demo, but stores the run under a deterministic artifact
+layout so the same command can be re-run and compared later.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from cmat.config import ExecutionConfig
+from cmat.workflow import (
+    run_simulator_adapter,
+    write_simulator_adapter_manifest,
+    write_simulator_adapter_portfolio,
+)
+
+from damped_oscillator_adapter import DampedOscillatorAdapter
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the damped-oscillator adapter in a batch-style artifact layout.",
+    )
+    parser.add_argument(
+        "--root-dir",
+        type=Path,
+        default=Path("artifacts") / "deployment",
+        help="Root directory that will contain deployment-style run folders.",
+    )
+    parser.add_argument(
+        "--run-name",
+        default="damped-oscillator-baseline",
+        help="Stable run folder name for reproducible reruns.",
+    )
+    parser.add_argument(
+        "--worker-count",
+        type=int,
+        default=1,
+        help="ExecutionConfig.worker_count passed to the adapter workflow.",
+    )
+    parser.add_argument(
+        "--start-method",
+        default="fork",
+        help="ExecutionConfig.start_method passed to the adapter workflow.",
+    )
+    parser.add_argument(
+        "--show-progress",
+        action="store_true",
+        help="Display tqdm progress for larger parameter grids.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    execution = ExecutionConfig(
+        worker_count=args.worker_count,
+        start_method=args.start_method,
+        show_progress=args.show_progress,
+    )
+    run_dir = args.root_dir / args.run_name
+    portfolio_dir = run_dir / "portfolio"
+    metadata_path = run_dir / "run_metadata.json"
+
+    result = run_simulator_adapter(
+        DampedOscillatorAdapter(),
+        execution=execution,
+    )
+    portfolio_paths = write_simulator_adapter_portfolio(
+        result,
+        output_dir=portfolio_dir,
+        title="Damped oscillator deployment example",
+    )
+    manifest_path = write_simulator_adapter_manifest(
+        result,
+        adapter_name="damped_oscillator",
+        metadata_path=metadata_path,
+        execution=execution,
+        notes={
+            "artifact_layout": "root_dir/run_name/{run_metadata.json, portfolio/...}",
+            "rerun_strategy": "reuse the same --run-name to overwrite a deterministic run folder",
+        },
+    )
+
+    print("Damped oscillator deployment example")
+    print("summary:", result.summary)
+    print("run directory:", run_dir)
+    print("run metadata:", manifest_path)
+    print(
+        "portfolio outputs:",
+        {name: str(path) for name, path in sorted(portfolio_paths.items())},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -518,22 +518,24 @@ class WorkflowTests(unittest.TestCase):
         context_calls = []
 
         class FakePool:
-            def __init__(self, process_count):
+            def __init__(self, process_count, initializer=None, initargs=()):
                 self.process_count = process_count
+                if initializer is not None:
+                    initializer(*initargs)
 
             def imap(self, func, tasks):
                 return map(func, tasks)
 
-            def close(self):
-                return None
+            def __enter__(self):
+                return self
 
-            def join(self):
-                return None
+            def __exit__(self, exc_type, exc, tb):
+                return False
 
         class FakeContext:
-            def Pool(self, process_count):
+            def Pool(self, process_count, initializer=None, initargs=()):
                 context_calls.append(process_count)
-                return FakePool(process_count)
+                return FakePool(process_count, initializer=initializer, initargs=initargs)
 
         with mock.patch("cmat.workflow.get_context", return_value=FakeContext()) as get_context_mock, mock.patch(
             "cmat.workflow.tqdm"
@@ -551,6 +553,78 @@ class WorkflowTests(unittest.TestCase):
         tqdm_mock.assert_not_called()
         self.assertEqual(context_calls, [3])
         np.testing.assert_array_equal(result.accepted, np.array([True, False]))
+
+    def test_run_simulator_adapter_rejects_inconsistent_parameter_keys(self):
+        class DemoAdapter:
+            def parameter_grid(self):
+                return [{"x": 1.0}, {"y": 2.0}]
+
+            def simulate(self, parameters):
+                return parameters
+
+            def score(self, simulated_observable):
+                return 0.0
+
+            def is_accepted(self, score):
+                return True
+
+            def summarize(self, *, parameter_grid, scores, accepted):
+                return {}
+
+        with self.assertRaisesRegex(ValueError, "same parameter keys"):
+            run_simulator_adapter(
+                DemoAdapter(),
+                execution=ExecutionConfig(worker_count=1, show_progress=False),
+            )
+
+    def test_run_simulator_adapter_terminates_pool_via_context_manager_on_error(self):
+        class DemoAdapter:
+            def parameter_grid(self):
+                return [{"x": 1.0}, {"x": 2.0}]
+
+            def simulate(self, parameters):
+                if parameters["x"] == 2.0:
+                    raise RuntimeError("boom")
+                return parameters["x"]
+
+            def score(self, simulated_observable):
+                return float(simulated_observable)
+
+            def is_accepted(self, score):
+                return True
+
+            def summarize(self, *, parameter_grid, scores, accepted):
+                return {}
+
+        exit_calls = []
+
+        class FakePool:
+            def __init__(self, process_count, initializer=None, initargs=()):
+                if initializer is not None:
+                    initializer(*initargs)
+
+            def imap(self, func, tasks):
+                return map(func, tasks)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                exit_calls.append(exc_type)
+                return False
+
+        class FakeContext:
+            def Pool(self, process_count, initializer=None, initargs=()):
+                return FakePool(process_count, initializer=initializer, initargs=initargs)
+
+        with mock.patch("cmat.workflow.get_context", return_value=FakeContext()):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                run_simulator_adapter(
+                    DemoAdapter(),
+                    execution=ExecutionConfig(worker_count=2, start_method="spawn", show_progress=False),
+                )
+
+        self.assertEqual(exit_calls, [RuntimeError])
 
     def test_write_simulator_adapter_portfolio_writes_report_table_and_figure(self):
         result = SimulatorAdapterRunResult(
@@ -581,6 +655,39 @@ class WorkflowTests(unittest.TestCase):
             table_payload = paths["table"].read_text(encoding="utf-8")
             self.assertIn("damping,stiffness,score,accepted", table_payload)
             self.assertIn("0.6,4.0,0.0,True", table_payload)
+
+    def test_write_simulator_adapter_portfolio_rejects_empty_result(self):
+        result = SimulatorAdapterRunResult(
+            parameter_grid=(),
+            scores=np.array([]),
+            accepted=np.array([], dtype=bool),
+            summary={},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "must not be empty"):
+                write_simulator_adapter_portfolio(
+                    result,
+                    output_dir=Path(tmpdir) / "portfolio",
+                )
+
+    def test_write_simulator_adapter_portfolio_rejects_mismatched_lengths(self):
+        result = SimulatorAdapterRunResult(
+            parameter_grid=(
+                {"damping": 0.3, "stiffness": 3.0},
+                {"damping": 0.6, "stiffness": 4.0},
+            ),
+            scores=np.array([0.25]),
+            accepted=np.array([False, True]),
+            summary={},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "matching lengths"):
+                write_simulator_adapter_portfolio(
+                    result,
+                    output_dir=Path(tmpdir) / "portfolio",
+                )
 
     def test_simulator_adapter_manifest_is_json_serializable(self):
         result = SimulatorAdapterRunResult(
@@ -650,6 +757,23 @@ class WorkflowTests(unittest.TestCase):
             self.assertEqual(payload["runtime"]["python_version"], "3.11.0")
             self.assertEqual(payload["notes"]["mode"], "batch")
             self.assertEqual(payload["best_parameters"], {"damping": 0.6, "stiffness": 4.0})
+
+    def test_simulator_adapter_manifest_rejects_mismatched_lengths(self):
+        result = SimulatorAdapterRunResult(
+            parameter_grid=(
+                {"damping": 0.3, "stiffness": 3.0},
+                {"damping": 0.6, "stiffness": 4.0},
+            ),
+            scores=np.array([0.25, 0.0]),
+            accepted=np.array([False]),
+            summary={},
+        )
+
+        with self.assertRaisesRegex(ValueError, "matching lengths"):
+            simulator_adapter_manifest(
+                result,
+                adapter_name="damped_oscillator",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -28,11 +28,16 @@ from cmat.workflow import (
     provenance_code_version,
     provenance_dependency_versions,
     provenance_runtime,
+    run_simulator_adapter,
+    simulator_adapter_manifest,
+    write_simulator_adapter_portfolio,
+    write_simulator_adapter_manifest,
     write_megno_grid_cache,
     write_posterior_samples_cache,
     write_ttv_grid_cache,
     workflow_manifest,
     write_workflow_manifest,
+    SimulatorAdapterRunResult,
 )
 
 
@@ -457,6 +462,194 @@ class WorkflowTests(unittest.TestCase):
                 config,
                 scoring_summary={"backend": "bayesian", "bayesian": {"sample_count": 4}},
             )
+
+    def test_run_simulator_adapter_returns_generic_inverse_model_result(self):
+        class DemoAdapter:
+            def parameter_grid(self):
+                return [{"stiffness": 1.0}, {"stiffness": 2.0}, {"stiffness": 3.0}]
+
+            def simulate(self, parameters):
+                return np.array([parameters["stiffness"], parameters["stiffness"] * 2.0])
+
+            def score(self, simulated_observable):
+                target = np.array([2.0, 4.0])
+                return float(np.sqrt(np.mean((simulated_observable - target) ** 2)))
+
+            def is_accepted(self, score):
+                return score <= 0.75
+
+            def summarize(self, *, parameter_grid, scores, accepted):
+                best_index = int(np.argmin(scores))
+                return {
+                    "accepted_count": int(np.sum(accepted)),
+                    "best_parameters": parameter_grid[best_index],
+                }
+
+        result = run_simulator_adapter(
+            DemoAdapter(),
+            execution=ExecutionConfig(worker_count=1, show_progress=False),
+        )
+
+        self.assertIsInstance(result, SimulatorAdapterRunResult)
+        np.testing.assert_allclose(result.scores, np.array([1.58113883, 0.0, 1.58113883]))
+        np.testing.assert_array_equal(result.accepted, np.array([False, True, False]))
+        self.assertEqual(result.summary["accepted_count"], 1)
+        self.assertEqual(result.summary["best_parameters"], {"stiffness": 2.0})
+        serialized = json.dumps(result.to_dict(), sort_keys=True)
+        self.assertIn('"accepted_count": 1', serialized)
+
+    def test_run_simulator_adapter_uses_execution_controls(self):
+        class DemoAdapter:
+            def parameter_grid(self):
+                return [{"x": 1.0}, {"x": 2.0}]
+
+            def simulate(self, parameters):
+                return parameters["x"]
+
+            def score(self, simulated_observable):
+                return float(simulated_observable)
+
+            def is_accepted(self, score):
+                return score < 2.0
+
+            def summarize(self, *, parameter_grid, scores, accepted):
+                return {"count": len(parameter_grid)}
+
+        context_calls = []
+
+        class FakePool:
+            def __init__(self, process_count):
+                self.process_count = process_count
+
+            def imap(self, func, tasks):
+                return map(func, tasks)
+
+            def close(self):
+                return None
+
+            def join(self):
+                return None
+
+        class FakeContext:
+            def Pool(self, process_count):
+                context_calls.append(process_count)
+                return FakePool(process_count)
+
+        with mock.patch("cmat.workflow.get_context", return_value=FakeContext()) as get_context_mock, mock.patch(
+            "cmat.workflow.tqdm"
+        ) as tqdm_mock:
+            result = run_simulator_adapter(
+                DemoAdapter(),
+                execution=ExecutionConfig(
+                    worker_count=3,
+                    start_method="spawn",
+                    show_progress=False,
+                ),
+            )
+
+        get_context_mock.assert_called_once_with("spawn")
+        tqdm_mock.assert_not_called()
+        self.assertEqual(context_calls, [3])
+        np.testing.assert_array_equal(result.accepted, np.array([True, False]))
+
+    def test_write_simulator_adapter_portfolio_writes_report_table_and_figure(self):
+        result = SimulatorAdapterRunResult(
+            parameter_grid=(
+                {"damping": 0.3, "stiffness": 3.0},
+                {"damping": 0.6, "stiffness": 4.0},
+            ),
+            scores=np.array([0.25, 0.0]),
+            accepted=np.array([False, True]),
+            summary={"accepted_count": 1},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = write_simulator_adapter_portfolio(
+                result,
+                output_dir=Path(tmpdir) / "portfolio",
+                title="Demo portfolio",
+            )
+
+            self.assertTrue(paths["report"].exists())
+            self.assertTrue(paths["summary"].exists())
+            self.assertTrue(paths["table"].exists())
+            self.assertTrue(paths["figure"].exists())
+
+            summary_payload = json.loads(paths["summary"].read_text(encoding="utf-8"))
+            self.assertEqual(summary_payload["accepted_count"], 1)
+            self.assertEqual(summary_payload["best_parameters"], {"damping": 0.6, "stiffness": 4.0})
+            table_payload = paths["table"].read_text(encoding="utf-8")
+            self.assertIn("damping,stiffness,score,accepted", table_payload)
+            self.assertIn("0.6,4.0,0.0,True", table_payload)
+
+    def test_simulator_adapter_manifest_is_json_serializable(self):
+        result = SimulatorAdapterRunResult(
+            parameter_grid=(
+                {"damping": 0.3, "stiffness": 3.0},
+                {"damping": 0.6, "stiffness": 4.0},
+            ),
+            scores=np.array([0.25, 0.0]),
+            accepted=np.array([False, True]),
+            summary={"accepted_count": 1},
+        )
+
+        manifest = simulator_adapter_manifest(
+            result,
+            adapter_name="damped_oscillator",
+            execution=ExecutionConfig(worker_count=2, start_method="spawn", show_progress=False),
+            dependency_versions={"numpy": "2.0.0"},
+            code_version={"git_commit": "abc123", "git_dirty": False},
+            runtime={"python_version": "3.11.0"},
+            notes={"mode": "batch"},
+        )
+        serialized = json.dumps(manifest, sort_keys=True)
+
+        self.assertIn('"adapter_name": "damped_oscillator"', serialized)
+        self.assertIn('"accepted_count": 1', serialized)
+        self.assertIn('"worker_count": 2', serialized)
+        self.assertIn('"best_score": 0.0', serialized)
+        self.assertIn('"mode": "batch"', serialized)
+
+    def test_write_simulator_adapter_manifest_persists_metadata_file(self):
+        result = SimulatorAdapterRunResult(
+            parameter_grid=(
+                {"damping": 0.3, "stiffness": 3.0},
+                {"damping": 0.6, "stiffness": 4.0},
+            ),
+            scores=np.array([0.25, 0.0]),
+            accepted=np.array([False, True]),
+            summary={"accepted_count": 1},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "deployment" / "run_metadata.json"
+
+            with mock.patch(
+                "cmat.workflow.provenance_dependency_versions",
+                return_value={"numpy": "2.0.0"},
+            ), mock.patch(
+                "cmat.workflow.provenance_code_version",
+                return_value={"git_commit": "abc123", "git_dirty": False},
+            ), mock.patch(
+                "cmat.workflow.provenance_runtime",
+                return_value={"python_version": "3.11.0"},
+            ):
+                written_path = write_simulator_adapter_manifest(
+                    result,
+                    adapter_name="damped_oscillator",
+                    metadata_path=output_path,
+                    execution=ExecutionConfig(worker_count=1, show_progress=False),
+                    notes={"mode": "batch"},
+                )
+
+            self.assertEqual(written_path, output_path)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["adapter_name"], "damped_oscillator")
+            self.assertEqual(payload["dependency_versions"], {"numpy": "2.0.0"})
+            self.assertEqual(payload["code_version"]["git_commit"], "abc123")
+            self.assertEqual(payload["runtime"]["python_version"], "3.11.0")
+            self.assertEqual(payload["notes"]["mode"], "batch")
+            self.assertEqual(payload["best_parameters"], {"damping": 0.6, "stiffness": 4.0})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the Stage 5 generic simulator-adapter workflow surface in `cmat.workflow` for portfolio bundles and persisted adapter-run manifests
- add damped-oscillator adapter examples for both portfolio-style output generation and deployment-style batch reruns
- extend the public docs with Stage 5 inverse-modeling framing, deployment-oriented usage, and a dedicated benchmarking guide

## Test plan
- MPLCONFIGDIR=/private/tmp/cmat-mplconfig XDG_CACHE_HOME=/private/tmp/cmat-cache /private/tmp/cmat-rebuild-env/bin/python -m unittest discover -s tests
