### PR TITLE
[codex] Add chi2 contour scoring surface

### DIFF
--- a/cmat/scoring.py
+++ b/cmat/scoring.py
@@ -138,6 +138,10 @@ class MassThresholds:
     backend: str = DEFAULT_MASS_THRESHOLD_BACKEND
     chi2_threshold: float | None = None
     rms_threshold: float | None = None
+    chi2_surface: np.ndarray | None = None
+    log_likelihood_surface: np.ndarray | None = None
+    period_ratios: np.ndarray | None = None
+    companion_masses: np.ndarray | None = None
     bayesian: BayesianScoringSummary | None = None
 
     def to_dict(self) -> dict[str, object]:
@@ -148,6 +152,16 @@ class MassThresholds:
             "chi2_threshold": self.chi2_threshold,
             "rms_threshold": self.rms_threshold,
         }
+        if self.chi2_surface is not None:
+            payload["chi2_surface"] = np.asarray(self.chi2_surface).tolist()
+        if self.log_likelihood_surface is not None:
+            payload["log_likelihood_surface"] = np.asarray(
+                self.log_likelihood_surface
+            ).tolist()
+        if self.period_ratios is not None:
+            payload["period_ratios"] = np.asarray(self.period_ratios).tolist()
+        if self.companion_masses is not None:
+            payload["companion_masses"] = np.asarray(self.companion_masses).tolist()
         if self.bayesian is not None:
             payload["bayesian"] = _serialize_value(self.bayesian)
         return payload
@@ -230,6 +244,10 @@ class Chi2AndRmsMassThresholdScorer:
             backend=DEFAULT_MASS_THRESHOLD_BACKEND,
             chi2_threshold=chi2_crit,
             rms_threshold=rms_crit,
+            chi2_surface=chi2_2d,
+            log_likelihood_surface=-0.5 * chi2_2d,
+            period_ratios=np.asarray(period_ratios, dtype=float),
+            companion_masses=np.asarray(companion_masses, dtype=float),
         )
 
 

--- a/cmat/scoring.py
+++ b/cmat/scoring.py
@@ -139,7 +139,7 @@ class MassThresholds:
     chi2_threshold: float | None = None
     rms_threshold: float | None = None
     chi2_surface: np.ndarray | None = None
-    log_likelihood_surface: np.ndarray | None = None
+    relative_log_likelihood_surface: np.ndarray | None = None
     period_ratios: np.ndarray | None = None
     companion_masses: np.ndarray | None = None
     bayesian: BayesianScoringSummary | None = None
@@ -154,9 +154,9 @@ class MassThresholds:
         }
         if self.chi2_surface is not None:
             payload["chi2_surface"] = np.asarray(self.chi2_surface).tolist()
-        if self.log_likelihood_surface is not None:
-            payload["log_likelihood_surface"] = np.asarray(
-                self.log_likelihood_surface
+        if self.relative_log_likelihood_surface is not None:
+            payload["relative_log_likelihood_surface"] = np.asarray(
+                self.relative_log_likelihood_surface
             ).tolist()
         if self.period_ratios is not None:
             payload["period_ratios"] = np.asarray(self.period_ratios).tolist()
@@ -245,7 +245,7 @@ class Chi2AndRmsMassThresholdScorer:
             chi2_threshold=chi2_crit,
             rms_threshold=rms_crit,
             chi2_surface=chi2_2d,
-            log_likelihood_surface=-0.5 * chi2_2d,
+            relative_log_likelihood_surface=-0.5 * chi2_2d,
             period_ratios=np.asarray(period_ratios, dtype=float),
             companion_masses=np.asarray(companion_masses, dtype=float),
         )

--- a/cmat/ttv_sim.py
+++ b/cmat/ttv_sim.py
@@ -217,22 +217,22 @@ class ttv_sim:
         return self.get_mass_thresholds().to_dict()
 
     def get_chi2_surface(self):
-        """Return the latest chi-squared surface on the (mp2, r) grid."""
+        """Return the latest chi-squared surface with shape (len(mp2s), len(rs))."""
 
         thresholds = self.get_mass_thresholds()
         if thresholds.chi2_surface is None:
             raise ValueError("chi2_surface is only available from the chi2_rms scoring backend")
         return np.asarray(thresholds.chi2_surface, dtype=float)
 
-    def get_log_likelihood_surface(self):
-        """Return the latest relative log-likelihood surface, -0.5 * chi2."""
+    def get_relative_log_likelihood_surface(self):
+        """Return the latest relative Gaussian log-likelihood proxy, -0.5 * chi2."""
 
         thresholds = self.get_mass_thresholds()
-        if thresholds.log_likelihood_surface is None:
+        if thresholds.relative_log_likelihood_surface is None:
             raise ValueError(
-                "log_likelihood_surface is only available from the chi2_rms scoring backend"
+                "relative_log_likelihood_surface is only available from the chi2_rms scoring backend"
             )
-        return np.asarray(thresholds.log_likelihood_surface, dtype=float)
+        return np.asarray(thresholds.relative_log_likelihood_surface, dtype=float)
 
     def plot_chi2_contour(
         self,
@@ -242,18 +242,26 @@ class ttv_sim:
         ax=None,
         cmap="viridis",
         show_threshold=True,
+        threshold_color="white",
     ):
-        """Plot a contour map of chi2 or relative log likelihood in r-mp2 space."""
+        """Plot a contour map of chi2 or relative Gaussian log-likelihood proxy.
+
+        The score surface is shaped as (len(companion_masses), len(period_ratios)),
+        with rows corresponding to companion masses and columns corresponding to
+        period ratios.
+        """
 
         thresholds = self.get_mass_thresholds()
         if statistic == "chi2":
             surface = self.get_chi2_surface()
             colorbar_label = r"$\chi^2$"
-        elif statistic in {"log_likelihood", "loglike"}:
-            surface = self.get_log_likelihood_surface()
-            colorbar_label = r"relative log likelihood $(-\chi^2 / 2)$"
+        elif statistic in {"relative_log_likelihood", "log_likelihood", "loglike"}:
+            surface = self.get_relative_log_likelihood_surface()
+            colorbar_label = r"relative log likelihood proxy $(-\chi^2 / 2)$"
         else:
-            raise ValueError("statistic must be 'chi2' or 'log_likelihood'")
+            raise ValueError(
+                "statistic must be 'chi2' or 'relative_log_likelihood'"
+            )
 
         period_ratios = (
             np.asarray(thresholds.period_ratios, dtype=float)
@@ -271,6 +279,9 @@ class ttv_sim:
             raise ValueError("contour plotting requires at least a 2x2 mp2-r grid")
         if not np.any(np.isfinite(surface)):
             raise ValueError("score surface must contain at least one finite value")
+        finite_surface = surface[np.isfinite(surface)]
+        if np.allclose(finite_surface, finite_surface[0]):
+            raise ValueError("score surface must vary across the grid for contour plotting")
 
         if ax is None:
             fig, ax = plt.subplots(figsize=(7, 5))
@@ -300,7 +311,7 @@ class ttv_sim:
                 companion_masses,
                 masked_surface,
                 levels=[thresholds.chi2_threshold],
-                colors="white",
+                colors=threshold_color,
                 linewidths=1.2,
             )
             ax.clabel(threshold_contour, fmt={thresholds.chi2_threshold: "chi2 limit"})

--- a/cmat/ttv_sim.py
+++ b/cmat/ttv_sim.py
@@ -216,6 +216,101 @@ class ttv_sim:
 
         return self.get_mass_thresholds().to_dict()
 
+    def get_chi2_surface(self):
+        """Return the latest chi-squared surface on the (mp2, r) grid."""
+
+        thresholds = self.get_mass_thresholds()
+        if thresholds.chi2_surface is None:
+            raise ValueError("chi2_surface is only available from the chi2_rms scoring backend")
+        return np.asarray(thresholds.chi2_surface, dtype=float)
+
+    def get_log_likelihood_surface(self):
+        """Return the latest relative log-likelihood surface, -0.5 * chi2."""
+
+        thresholds = self.get_mass_thresholds()
+        if thresholds.log_likelihood_surface is None:
+            raise ValueError(
+                "log_likelihood_surface is only available from the chi2_rms scoring backend"
+            )
+        return np.asarray(thresholds.log_likelihood_surface, dtype=float)
+
+    def plot_chi2_contour(
+        self,
+        *,
+        statistic="chi2",
+        levels=20,
+        ax=None,
+        cmap="viridis",
+        show_threshold=True,
+    ):
+        """Plot a contour map of chi2 or relative log likelihood in r-mp2 space."""
+
+        thresholds = self.get_mass_thresholds()
+        if statistic == "chi2":
+            surface = self.get_chi2_surface()
+            colorbar_label = r"$\chi^2$"
+        elif statistic in {"log_likelihood", "loglike"}:
+            surface = self.get_log_likelihood_surface()
+            colorbar_label = r"relative log likelihood $(-\chi^2 / 2)$"
+        else:
+            raise ValueError("statistic must be 'chi2' or 'log_likelihood'")
+
+        period_ratios = (
+            np.asarray(thresholds.period_ratios, dtype=float)
+            if thresholds.period_ratios is not None
+            else np.asarray(self.rs, dtype=float)
+        )
+        companion_masses = (
+            np.asarray(thresholds.companion_masses, dtype=float)
+            if thresholds.companion_masses is not None
+            else np.asarray(self.mp2s, dtype=float)
+        )
+        if surface.shape != (len(companion_masses), len(period_ratios)):
+            raise ValueError("score surface shape must match the configured mp2-r grid")
+        if len(period_ratios) < 2 or len(companion_masses) < 2:
+            raise ValueError("contour plotting requires at least a 2x2 mp2-r grid")
+        if not np.any(np.isfinite(surface)):
+            raise ValueError("score surface must contain at least one finite value")
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=(7, 5))
+        else:
+            fig = ax.figure
+
+        masked_surface = np.ma.masked_invalid(surface)
+        contour = ax.contourf(
+            period_ratios,
+            companion_masses,
+            masked_surface,
+            levels=levels,
+            cmap=cmap,
+        )
+        colorbar = fig.colorbar(contour, ax=ax)
+        colorbar.set_label(colorbar_label)
+
+        if (
+            statistic == "chi2"
+            and show_threshold
+            and thresholds.chi2_threshold is not None
+            and np.isfinite(thresholds.chi2_threshold)
+            and np.nanmin(surface) <= thresholds.chi2_threshold <= np.nanmax(surface)
+        ):
+            threshold_contour = ax.contour(
+                period_ratios,
+                companion_masses,
+                masked_surface,
+                levels=[thresholds.chi2_threshold],
+                colors="white",
+                linewidths=1.2,
+            )
+            ax.clabel(threshold_contour, fmt={thresholds.chi2_threshold: "chi2 limit"})
+
+        ax.set_xlabel(r"$P_2/P_1$")
+        ax.set_ylabel(r"$M_2$ [$M_\oplus$]")
+        ax.set_title("TTV score surface")
+        ax.grid(alpha=0.25)
+        return fig, ax
+
     def simulation_m(self, par):
         r, mp2 = par  # unpack parameters
         prop = self.prop

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -404,9 +404,9 @@ Important attributes and methods:
 | `get_m_crit()` | method | Legacy-compatible chi2/RMS return signature; Bayesian mode warns and returns empty legacy arrays |
 | `get_mass_thresholds()` | method | Return the full `MassThresholds` object, including experimental Bayesian summaries |
 | `get_scoring_summary()` | method | Return a JSON-serializable summary of the latest scoring result |
-| `get_chi2_surface()` | method | Return the latest 2D chi2 surface on the companion-mass by period-ratio grid |
-| `get_log_likelihood_surface()` | method | Return the latest relative log-likelihood surface, computed as `-0.5 * chi2` |
-| `plot_chi2_contour(statistic=...)` | method | Plot a contour map in the `P_2/P_1` by `M_2` plane for chi2 or relative log likelihood |
+| `get_chi2_surface()` | method | Return the latest 2D chi2 surface with shape `(len(companion_masses), len(period_ratios))` |
+| `get_relative_log_likelihood_surface()` | method | Return the latest relative Gaussian log-likelihood proxy, computed as `-0.5 * chi2` up to an additive constant |
+| `plot_chi2_contour(statistic=...)` | method | Plot a contour map in the `P_2/P_1` by `M_2` plane for chi2 or the relative log-likelihood proxy |
 | `simulation_m((r, mp2))` | method | Run one MEGNO simulation |
 | `run_megno(number_of_threads)` | method | Run MEGNO across the full grid |
 | `plot_megno()` | method | Plot the MEGNO map |
@@ -416,7 +416,7 @@ Important attributes and methods:
 
 `get_critical_masses()` and `get_m_crit()` return the same pair of arrays for the legacy chi2/RMS backend: the first rejected masses under the current `chi^2` threshold and the first rejected masses under the current RMS threshold. A period-ratio column only contributes an entry if the reduced grid actually crosses the corresponding rejection criterion, and grid points whose REBOUND integration terminated early are excluded explicitly instead of being treated as finite constraints.
 
-The default `chi2_rms` backend also retains the full chi2 score surface used to derive those limits. After `get_critical_masses()` or `get_m_crit()`, call `get_chi2_surface()` to inspect the raw `(companion_mass, period_ratio)` grid, `get_log_likelihood_surface()` to inspect the relative `-0.5 * chi2` transform, or `plot_chi2_contour(statistic="chi2")` / `plot_chi2_contour(statistic="log_likelihood")` to draw the corresponding contour map. Contour plotting requires at least a 2x2 grid.
+The default `chi2_rms` backend also retains the full chi2 score surface used to derive the legacy chi2 critical-mass curve. `chi2_surface` is shaped as `(len(companion_masses), len(period_ratios))`, with rows corresponding to companion masses and columns corresponding to period ratios. After `get_critical_masses()` or `get_m_crit()`, call `get_chi2_surface()` to inspect that raw grid, `get_relative_log_likelihood_surface()` to inspect the relative Gaussian log-likelihood proxy `-0.5 * chi2` up to an additive constant shared across the grid, or `plot_chi2_contour(statistic="chi2")` / `plot_chi2_contour(statistic="relative_log_likelihood")` to draw the corresponding contour map. Contour plotting requires at least a 2x2 grid and a non-constant finite surface.
 
 When the active backend is Bayesian, `get_m_crit()` remains available only for backward compatibility; the primary result surface is `get_mass_thresholds()`. In that summary, `credible_upper_bound` is a cumulative-posterior credible bound, while `rejection_upper_bound` is the first companion mass rejected by the configured evidence-ratio threshold. The serialized `upper_bound` field remains as a compatibility alias for `credible_upper_bound`.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -404,6 +404,9 @@ Important attributes and methods:
 | `get_m_crit()` | method | Legacy-compatible chi2/RMS return signature; Bayesian mode warns and returns empty legacy arrays |
 | `get_mass_thresholds()` | method | Return the full `MassThresholds` object, including experimental Bayesian summaries |
 | `get_scoring_summary()` | method | Return a JSON-serializable summary of the latest scoring result |
+| `get_chi2_surface()` | method | Return the latest 2D chi2 surface on the companion-mass by period-ratio grid |
+| `get_log_likelihood_surface()` | method | Return the latest relative log-likelihood surface, computed as `-0.5 * chi2` |
+| `plot_chi2_contour(statistic=...)` | method | Plot a contour map in the `P_2/P_1` by `M_2` plane for chi2 or relative log likelihood |
 | `simulation_m((r, mp2))` | method | Run one MEGNO simulation |
 | `run_megno(number_of_threads)` | method | Run MEGNO across the full grid |
 | `plot_megno()` | method | Plot the MEGNO map |
@@ -412,6 +415,8 @@ Important attributes and methods:
 | `megno_dt` / `megno_runtime` | attributes | Controls for MEGNO timestep and integration runtime |
 
 `get_critical_masses()` and `get_m_crit()` return the same pair of arrays for the legacy chi2/RMS backend: the first rejected masses under the current `chi^2` threshold and the first rejected masses under the current RMS threshold. A period-ratio column only contributes an entry if the reduced grid actually crosses the corresponding rejection criterion, and grid points whose REBOUND integration terminated early are excluded explicitly instead of being treated as finite constraints.
+
+The default `chi2_rms` backend also retains the full chi2 score surface used to derive those limits. After `get_critical_masses()` or `get_m_crit()`, call `get_chi2_surface()` to inspect the raw `(companion_mass, period_ratio)` grid, `get_log_likelihood_surface()` to inspect the relative `-0.5 * chi2` transform, or `plot_chi2_contour(statistic="chi2")` / `plot_chi2_contour(statistic="log_likelihood")` to draw the corresponding contour map. Contour plotting requires at least a 2x2 grid.
 
 When the active backend is Bayesian, `get_m_crit()` remains available only for backward compatibility; the primary result surface is `get_mass_thresholds()`. In that summary, `credible_upper_bound` is a cumulative-posterior credible bound, while `rejection_upper_bound` is the first companion mass rejected by the configured evidence-ratio threshold. The serialized `upper_bound` field remains as a compatibility alias for `credible_upper_bound`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -73,6 +73,7 @@ simulation.ttv_results = [
 ]
 chi2_limit, rms_limit = simulation.get_critical_masses()
 chi2_surface = simulation.get_chi2_surface()
+relative_log_likelihood_surface = simulation.get_relative_log_likelihood_surface()
 ```
 
 This is not a replacement for the full notebook. It is the smallest currently maintained example of the repository's forward-simulation half.
@@ -81,7 +82,7 @@ For grids with at least two period ratios and two companion masses, the same sco
 
 ```python
 fig, ax = simulation.plot_chi2_contour(statistic="chi2")
-fig, ax = simulation.plot_chi2_contour(statistic="log_likelihood")
+fig, ax = simulation.plot_chi2_contour(statistic="relative_log_likelihood")
 ```
 
 ## Full narrative example

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -72,9 +72,17 @@ simulation.ttv_results = [
     simulation.calculate_rebound((1.5, 20.0)),
 ]
 chi2_limit, rms_limit = simulation.get_critical_masses()
+chi2_surface = simulation.get_chi2_surface()
 ```
 
 This is not a replacement for the full notebook. It is the smallest currently maintained example of the repository's forward-simulation half.
+
+For grids with at least two period ratios and two companion masses, the same scoring result can be visualized in the `P_2/P_1` by `M_2` plane:
+
+```python
+fig, ax = simulation.plot_chi2_contour(statistic="chi2")
+fig, ax = simulation.plot_chi2_contour(statistic="log_likelihood")
+```
 
 ## Full narrative example
 

--- a/tests/test_ttv_scoring.py
+++ b/tests/test_ttv_scoring.py
@@ -99,7 +99,7 @@ class TtvScoringTests(unittest.TestCase):
         np.testing.assert_array_equal(scoring_summary["chi2"], [20.0, 10.0])
         np.testing.assert_array_equal(scoring_summary["rms"], [20.0, 10.0])
 
-    def test_get_m_crit_retains_chi2_and_log_likelihood_surfaces(self):
+    def test_get_m_crit_retains_chi2_and_relative_log_likelihood_surfaces(self):
         prop = [
             {
                 "orbital_distance": 1.0,
@@ -129,13 +129,19 @@ class TtvScoringTests(unittest.TestCase):
 
         expected_chi2 = np.array([[0.75, 243.0], [243.0, 243.0]])
         np.testing.assert_allclose(sim.get_chi2_surface(), expected_chi2)
-        np.testing.assert_allclose(sim.get_log_likelihood_surface(), -0.5 * expected_chi2)
+        np.testing.assert_allclose(
+            sim.get_relative_log_likelihood_surface(),
+            -0.5 * expected_chi2,
+        )
 
         summary = sim.get_scoring_summary()
         self.assertEqual(summary["period_ratios"], [1.0, 2.0])
         self.assertEqual(summary["companion_masses"], [10.0, 20.0])
         np.testing.assert_allclose(summary["chi2_surface"], expected_chi2)
-        np.testing.assert_allclose(summary["log_likelihood_surface"], -0.5 * expected_chi2)
+        np.testing.assert_allclose(
+            summary["relative_log_likelihood_surface"],
+            -0.5 * expected_chi2,
+        )
 
     def test_plot_chi2_contour_draws_score_surface(self):
         prop = [
@@ -169,7 +175,7 @@ class TtvScoringTests(unittest.TestCase):
         self.assertGreaterEqual(len(fig.axes), 2)
         plt.close(fig)
 
-    def test_plot_chi2_contour_supports_log_likelihood_surface(self):
+    def test_plot_chi2_contour_supports_relative_log_likelihood_surface(self):
         prop = [
             {
                 "orbital_distance": 1.0,
@@ -194,10 +200,42 @@ class TtvScoringTests(unittest.TestCase):
         ]
         sim.get_m_crit()
 
-        fig, _ = sim.plot_chi2_contour(statistic="log_likelihood", levels=4)
+        fig, _ = sim.plot_chi2_contour(
+            statistic="relative_log_likelihood",
+            levels=4,
+        )
 
         self.assertIn("log likelihood", fig.axes[1].get_ylabel())
         plt.close(fig)
+
+    def test_plot_chi2_contour_rejects_constant_finite_surface(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        sim = ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        identical_signal = np.array([1.0, 1.0, 1.0, 1.0])
+        sim.ttv_results = [
+            identical_signal,
+            identical_signal,
+            identical_signal,
+            identical_signal,
+        ]
+        sim.get_m_crit()
+
+        with self.assertRaisesRegex(ValueError, "must vary across the grid"):
+            sim.plot_chi2_contour(levels=4)
 
     def test_get_m_crit_ignores_zero_signal_rows(self):
         prop = [

--- a/tests/test_ttv_scoring.py
+++ b/tests/test_ttv_scoring.py
@@ -13,6 +13,8 @@ MPLCONFIGDIR = Path(tempfile.gettempdir()) / "cmat-test-mplconfig"
 MPLCONFIGDIR.mkdir(exist_ok=True)
 os.environ.setdefault("MPLCONFIGDIR", str(MPLCONFIGDIR))
 
+from matplotlib import pyplot as plt
+
 from cmat import TTVSimulation, scoring
 from cmat.config import BayesianScoringConfig
 from cmat.scoring import BayesianMassThresholdScorer, MassThresholds, make_mass_threshold_scorer
@@ -96,6 +98,106 @@ class TtvScoringTests(unittest.TestCase):
         self.assertEqual(scoring_summary["backend"], "chi2_rms")
         np.testing.assert_array_equal(scoring_summary["chi2"], [20.0, 10.0])
         np.testing.assert_array_equal(scoring_summary["rms"], [20.0, 10.0])
+
+    def test_get_m_crit_retains_chi2_and_log_likelihood_surfaces(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        sim = ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        low_signal = np.array([0.5, 0.5, 0.5, 0.5])
+        high_signal = np.array([10.0, 10.0, 10.0, 10.0])
+        sim.ttv_results = [
+            low_signal,
+            high_signal,
+            high_signal,
+            high_signal,
+        ]
+
+        sim.get_m_crit()
+
+        expected_chi2 = np.array([[0.75, 243.0], [243.0, 243.0]])
+        np.testing.assert_allclose(sim.get_chi2_surface(), expected_chi2)
+        np.testing.assert_allclose(sim.get_log_likelihood_surface(), -0.5 * expected_chi2)
+
+        summary = sim.get_scoring_summary()
+        self.assertEqual(summary["period_ratios"], [1.0, 2.0])
+        self.assertEqual(summary["companion_masses"], [10.0, 20.0])
+        np.testing.assert_allclose(summary["chi2_surface"], expected_chi2)
+        np.testing.assert_allclose(summary["log_likelihood_surface"], -0.5 * expected_chi2)
+
+    def test_plot_chi2_contour_draws_score_surface(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        sim = ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        sim.ttv_results = [
+            np.array([0.5, 0.5, 0.5, 0.5]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+        ]
+        sim.get_m_crit()
+
+        fig, ax = sim.plot_chi2_contour(levels=4)
+
+        self.assertEqual(ax.get_xlabel(), r"$P_2/P_1$")
+        self.assertEqual(ax.get_ylabel(), r"$M_2$ [$M_\oplus$]")
+        self.assertGreaterEqual(len(fig.axes), 2)
+        plt.close(fig)
+
+    def test_plot_chi2_contour_supports_log_likelihood_surface(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        sim = ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        sim.ttv_results = [
+            np.array([0.5, 0.5, 0.5, 0.5]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+        ]
+        sim.get_m_crit()
+
+        fig, _ = sim.plot_chi2_contour(statistic="log_likelihood", levels=4)
+
+        self.assertIn("log likelihood", fig.axes[1].get_ylabel())
+        plt.close(fig)
 
     def test_get_m_crit_ignores_zero_signal_rows(self):
         prop = [
@@ -520,6 +622,9 @@ class TtvScoringTests(unittest.TestCase):
             scoring_backend.calls[0]["companion_masses"],
             np.array([10.0, 20.0]),
         )
+
+        with self.assertRaisesRegex(ValueError, "chi2_surface"):
+            simulation.get_chi2_surface()
 
     def test_scorer_factory_supports_bayesian_contract_backend(self):
         scorer = make_mass_threshold_scorer("bayesian")


### PR DESCRIPTION
## Summary
- retain the full chi2 surface and its relative Gaussian log-likelihood transform, `-0.5 * chi2`, in the default chi2/rms scoring backend
- add TTVSimulation helpers to fetch the 2D surfaces and draw contour maps in the period-ratio vs companion-mass plane
- document the new plotting path and add regression tests for surface serialization and contour plotting

RMS critical-mass behavior is unchanged, and RMS surface visualization is out of scope for this PR.

## Validation
- /Users/troy/anaconda3/envs/cmat/bin/python -m pytest tests