### PR TITLE
refactor: split TTV simulation helpers from legacy facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ For new code, prefer `cmat.TransitFitWorkflow` and `cmat.TTVSimulation`. The old
 
 The current industry rebuild also exposes import-safe pure helpers under `cmat.domain` for units, timing, residual scoring, and mass-limit extraction. Those functions are intended for new tests and adapters while the legacy notebook-compatible APIs remain unchanged.
 
+The industry rebuild now also keeps `TTVSimulation` as a compatibility facade while exposing smaller simulation and plotting helpers under `cmat.simulation` and `cmat.plotting` for tests and future workflow or CLI entry points.
+
 ## Example Notebook
 
 Run the included full notebook:

--- a/cmat/plotting/__init__.py
+++ b/cmat/plotting/__init__.py
@@ -1,0 +1,6 @@
+"""Focused plotting helpers for score and MEGNO surfaces."""
+
+__all__ = [
+    "megno",
+    "score_surfaces",
+]

--- a/cmat/plotting/megno.py
+++ b/cmat/plotting/megno.py
@@ -36,7 +36,7 @@ def plot_megno_surface(
     ax.set_xlim(extent[0], extent[1])
     ax.set_xlabel("$P_2/P_1$")
     ax.set_ylim(extent[2], extent[3])
-    ax.set_ylabel("Mass [$M_j$]")
+    ax.set_ylabel("Mass [$M_\\oplus$]")
     image = ax.imshow(
         results2d,
         interpolation="none",
@@ -53,5 +53,5 @@ def plot_megno_surface(
     ax.grid()
     ax.set_xticks([1.5, 2, 2.5, 3, 3.3, 3.5, 3.8, 4])
     ax.set_xlabel(r"$P_2/P_1$")
-    ax.set_ylabel(r"$M_2$ [$M_j$]")
+    ax.set_ylabel(r"$M_2$ [$M_\oplus$]")
     return fig, ax

--- a/cmat/plotting/megno.py
+++ b/cmat/plotting/megno.py
@@ -1,0 +1,57 @@
+"""Plotting helpers for MEGNO surfaces."""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+
+def plot_megno_surface(
+    *,
+    period_ratios,
+    companion_masses,
+    megno_results,
+    ax=None,
+    cmap="RdYlGn_r",
+):
+    """Plot a MEGNO grid as a 2D color map."""
+
+    period_ratios = np.asarray(period_ratios, dtype=float)
+    companion_masses = np.asarray(companion_masses, dtype=float)
+    results2d = np.asarray(megno_results, dtype=float).reshape(
+        len(companion_masses), len(period_ratios)
+    )
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(7, 5))
+    else:
+        fig = ax.figure
+
+    extent = [
+        float(np.min(period_ratios)),
+        float(np.max(period_ratios)),
+        float(np.min(companion_masses)),
+        float(np.max(companion_masses)),
+    ]
+    ax.set_xlim(extent[0], extent[1])
+    ax.set_xlabel("$P_2/P_1$")
+    ax.set_ylim(extent[2], extent[3])
+    ax.set_ylabel("Mass [$M_j$]")
+    image = ax.imshow(
+        results2d,
+        interpolation="none",
+        vmin=1.9,
+        vmax=10,
+        cmap=cmap,
+        origin="lower",
+        aspect="auto",
+        extent=extent,
+        alpha=0.8,
+    )
+    colorbar = plt.colorbar(image, ax=ax)
+    colorbar.set_label("MEGNO $\\langle Y \\rangle$")
+    ax.grid()
+    ax.set_xticks([1.5, 2, 2.5, 3, 3.3, 3.5, 3.8, 4])
+    ax.set_xlabel(r"$P_2/P_1$")
+    ax.set_ylabel(r"$M_2$ [$M_j$]")
+    return fig, ax

--- a/cmat/plotting/score_surfaces.py
+++ b/cmat/plotting/score_surfaces.py
@@ -1,0 +1,80 @@
+"""Plotting helpers for chi-squared-style score surfaces."""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+
+def plot_score_surface(
+    *,
+    period_ratios,
+    companion_masses,
+    surface,
+    statistic_label,
+    vmin=None,
+    vmax=None,
+    threshold=None,
+    show_threshold=True,
+    threshold_color="white",
+    levels=None,
+    ax=None,
+    cmap="plasma",
+    figsize=(4, 3.2),
+    dpi=200,
+):
+    """Plot a score surface over companion mass and period-ratio grids."""
+
+    period_ratios = np.asarray(period_ratios, dtype=float)
+    companion_masses = np.asarray(companion_masses, dtype=float)
+    surface = np.asarray(surface, dtype=float)
+
+    if surface.shape != (len(companion_masses), len(period_ratios)):
+        raise ValueError("score surface shape must match the configured mp2-r grid")
+    if len(period_ratios) < 2 or len(companion_masses) < 2:
+        raise ValueError("contour plotting requires at least a 2x2 mp2-r grid")
+    if not np.any(np.isfinite(surface)):
+        raise ValueError("score surface must contain at least one finite value")
+    finite_surface = surface[np.isfinite(surface)]
+    surface_varies = not np.allclose(finite_surface, finite_surface[0])
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    else:
+        fig = ax.figure
+
+    masked_surface = np.ma.masked_invalid(surface)
+    x_grid, y_grid = np.meshgrid(period_ratios, companion_masses)
+    mesh = ax.pcolor(
+        x_grid,
+        y_grid,
+        masked_surface,
+        cmap=cmap,
+        vmin=vmin,
+        vmax=vmax,
+    )
+    colorbar = fig.colorbar(mesh, ax=ax)
+    colorbar.set_label(statistic_label)
+
+    if (
+        show_threshold
+        and threshold is not None
+        and np.isfinite(threshold)
+        and surface_varies
+        and np.nanmin(surface) <= threshold <= np.nanmax(surface)
+    ):
+        threshold_contour = ax.contour(
+            period_ratios,
+            companion_masses,
+            masked_surface,
+            levels=[threshold],
+            colors=threshold_color,
+            linewidths=1.2,
+        )
+        ax.clabel(threshold_contour, fmt={threshold: "limit"})
+
+    ax.set_xlabel(r"$P_2/P_1$")
+    ax.set_ylabel(r"Mass [$M_\oplus$]")
+    ax.set_yscale("log")
+    ax.grid(alpha=0.25)
+    return fig, ax

--- a/cmat/simulation/__init__.py
+++ b/cmat/simulation/__init__.py
@@ -1,0 +1,7 @@
+"""Focused simulation helpers for TTV and MEGNO workflows."""
+
+__all__ = [
+    "execution",
+    "megno",
+    "rebound_ttv",
+]

--- a/cmat/simulation/execution.py
+++ b/cmat/simulation/execution.py
@@ -1,0 +1,59 @@
+"""Import-safe execution helpers for simulation grids."""
+
+from __future__ import annotations
+
+from multiprocessing import get_context
+from numbers import Integral
+
+from tqdm.auto import tqdm
+
+
+def build_mass_ratio_parameter_grid(period_ratios, companion_masses):
+    """Return legacy-ordered `(period_ratio, companion_mass)` pairs."""
+
+    return [
+        (float(period_ratio), float(companion_mass))
+        for companion_mass in companion_masses
+        for period_ratio in period_ratios
+    ]
+
+
+def resolve_worker_count(number_of_threads=None, *, worker_count=1):
+    """Resolve the effective worker count from legacy and configured inputs."""
+
+    if number_of_threads is None:
+        number_of_threads = worker_count
+    if isinstance(number_of_threads, bool) or not isinstance(
+        number_of_threads, Integral
+    ):
+        raise TypeError("number_of_threads must be an integer")
+    number_of_threads = int(number_of_threads)
+    if number_of_threads <= 0:
+        raise ValueError("number_of_threads must be positive")
+    return number_of_threads
+
+
+def maybe_run_in_pool(
+    worker,
+    parameters,
+    *,
+    worker_count,
+    start_method="fork",
+    show_progress=True,
+    get_context_fn=get_context,
+    progress_wrapper=tqdm,
+):
+    """Run a picklable worker over a parameter grid, serially or in a pool."""
+
+    parameters = list(parameters)
+    if worker_count == 1:
+        iterator = map(worker, parameters)
+        if show_progress:
+            iterator = progress_wrapper(iterator, total=len(parameters))
+        return list(iterator)
+
+    with get_context_fn(start_method).Pool(worker_count) as pool:
+        iterator = pool.imap(worker, parameters)
+        if show_progress:
+            iterator = progress_wrapper(iterator, total=len(parameters))
+        return list(iterator)

--- a/cmat/simulation/megno.py
+++ b/cmat/simulation/megno.py
@@ -1,0 +1,115 @@
+"""REBOUND-backed MEGNO simulation helpers."""
+
+from __future__ import annotations
+
+from functools import partial
+from multiprocessing import get_context
+from pathlib import Path
+
+import numpy as np
+import rebound
+from tqdm.auto import tqdm
+
+from ..domain.units import ME_TO_MS, MJ_TO_MS
+from .execution import build_mass_ratio_parameter_grid, maybe_run_in_pool
+
+
+def calculate_megno(*, parameters, prop, dt, runtime):
+    """Calculate MEGNO for one period-ratio/mass pair."""
+
+    r, mp2 = parameters
+    ms = prop[0]["Ms"]
+    mp1 = prop[0]["Mp"]
+    a1 = prop[0]["orbital_distance"]
+    a2 = a1 * r ** (2 / 3)
+
+    sim = rebound.Simulation()
+    sim.integrator = "whfast"
+    sim.ri_whfast.safe_mode = 0
+    sim.add(m=ms)
+    sim.add(m=mp1 * MJ_TO_MS, a=a1, e=0)
+    sim.add(m=mp2 * ME_TO_MS, a=a2, e=0)
+    sim.move_to_com()
+
+    period_min = min([sim.particles[1].P, sim.particles[2].P])
+    sim.dt = dt * period_min
+    sim.init_megno()
+    sim.exit_max_distance = 20.0
+    try:
+        sim.integrate(runtime * period_min, exact_finish_time=0)
+        return sim.calculate_megno()
+    except rebound.Escape:
+        return 10.0
+
+
+def save_megno_grid_cache(
+    *,
+    cache_path,
+    period_ratios,
+    companion_masses,
+    megno_results,
+):
+    """Persist MEGNO grid results as a compressed `.npz` bundle."""
+
+    cache_path = Path(cache_path)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with cache_path.open("wb") as handle:
+        np.savez_compressed(
+            handle,
+            period_ratios=np.asarray(period_ratios, dtype=float),
+            companion_masses=np.asarray(companion_masses, dtype=float),
+            megno_results=np.asarray(megno_results, dtype=float),
+        )
+    return cache_path
+
+
+def load_megno_grid_cache(*, cache_path):
+    """Load MEGNO grid results from a compressed `.npz` bundle."""
+
+    with np.load(cache_path, allow_pickle=False) as payload:
+        return {name: payload[name] for name in payload.files}
+
+
+def run_megno_grid(
+    *,
+    period_ratios,
+    companion_masses,
+    prop,
+    dt,
+    runtime,
+    worker_count=1,
+    start_method="fork",
+    show_progress=True,
+    number_of_threads=None,
+    use_cache=False,
+    cache_path=None,
+    overwrite_cache=False,
+    get_context_fn=get_context,
+    progress_wrapper=tqdm,
+):
+    """Run MEGNO over a grid while preserving legacy ordering and caching."""
+
+    if use_cache and cache_path is not None and Path(cache_path).exists():
+        if not overwrite_cache:
+            payload = load_megno_grid_cache(cache_path=cache_path)
+            return payload["megno_results"].tolist()
+
+    parameters = build_mass_ratio_parameter_grid(period_ratios, companion_masses)
+    worker = partial(calculate_megno, prop=prop, dt=dt, runtime=runtime)
+    results = maybe_run_in_pool(
+        worker,
+        parameters,
+        worker_count=worker_count if number_of_threads is None else number_of_threads,
+        start_method=start_method,
+        show_progress=show_progress,
+        get_context_fn=get_context_fn,
+        progress_wrapper=progress_wrapper,
+    )
+    if use_cache and cache_path is not None:
+        save_megno_grid_cache(
+            cache_path=cache_path,
+            period_ratios=period_ratios,
+            companion_masses=companion_masses,
+            megno_results=results,
+        )
+    return results

--- a/cmat/simulation/rebound_ttv.py
+++ b/cmat/simulation/rebound_ttv.py
@@ -1,0 +1,97 @@
+"""REBOUND-backed transit-timing simulation helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import rebound
+
+from ..domain.units import ME_TO_MS, MJ_TO_MS
+
+RJ_TO_RS = 0.102792236
+LEGACY_RS_TO_AU = 0.00464913034
+
+
+def calculate_rebound_ttv(
+    *,
+    parameters,
+    prop,
+    n_transit_simulations,
+    e1=0,
+    e2=0,
+    inc1=0,
+    inc2=0,
+    f1=0,
+    f2=0,
+):
+    """Simulate one REBOUND TTV series for a single period-ratio/mass pair."""
+
+    r, mp2 = parameters
+    ms = prop[0]["Ms"]
+    mp1 = prop[0]["Mp"]
+    a1 = prop[0]["orbital_distance"]
+    a2 = a1 * r ** (2 / 3)
+    rstar = prop[0]["Rs"]
+    rp = prop[0]["Rp"]
+
+    sim = rebound.Simulation()
+    sim.integrator = "whfast"
+    sim.ri_whfast.safe_mode = 0
+    sim.collision = "direct"
+    sim.add(m=ms, r=rstar * LEGACY_RS_TO_AU)
+    sim.add(
+        m=mp1 * MJ_TO_MS,
+        r=rp * RJ_TO_RS * LEGACY_RS_TO_AU,
+        a=a1,
+        e=e1,
+        inc=inc1,
+        f=f1,
+    )
+    sim.add(m=mp2 * ME_TO_MS, a=a2, e=e2, inc=inc2, f=f2)
+    sim.move_to_com()
+    sim.exit_max_distance = 5.0
+
+    period_min = min([sim.particles[1].P, sim.particles[2].P])
+    transit_count = int(n_transit_simulations)
+    transittimes = np.zeros(transit_count)
+    particles = sim.particles
+    index = 0
+    while index < transit_count:
+        y_old = particles[1].y - particles[0].y
+        t_old = sim.t
+        try:
+            sim.integrate(sim.t + period_min / 4)
+        except rebound.Escape:
+            break
+        except rebound.Collision:
+            break
+        t_new = sim.t
+        if y_old * (particles[1].y - particles[0].y) < 0.0 and (
+            particles[1].x - particles[0].x > 0.0
+        ):
+            while t_new - t_old > 1e-9:
+                if y_old * (particles[1].y - particles[0].y) < 0.0:
+                    t_new = sim.t
+                else:
+                    t_old = sim.t
+                try:
+                    sim.integrate((t_new + t_old) / 2.0)
+                except (rebound.Escape, rebound.Collision):
+                    break
+            transittimes[index] = sim.t
+            index += 1
+            try:
+                sim.integrate(sim.t + 5e-5)
+            except (rebound.Escape, rebound.Collision):
+                break
+
+    if index < transit_count:
+        return np.full(transit_count, np.nan)
+
+    c, m = np.linalg.lstsq(
+        np.vstack([np.ones(transit_count), range(transit_count)]).T,
+        transittimes,
+        rcond=None,
+    )[0]
+    return (transittimes - m * np.array(range(transit_count)) - c) * (
+        3600 * 24.0 * 365.0 / 2.0 / np.pi
+    )

--- a/cmat/ttv_sim.py
+++ b/cmat/ttv_sim.py
@@ -308,7 +308,9 @@ class ttv_sim:
         overwrite_cache=False,
     ):
         if use_cache and cache_path is None:
-            raise ValueError("cache_path is required when use_cache=True for run_megno()")
+            raise ValueError(
+                "cache_path is required when use_cache=True for run_megno()"
+            )
         if use_cache and cache_path is not None and Path(cache_path).exists():
             if not overwrite_cache:
                 self.load_megno_grid_cache(cache_path)

--- a/cmat/ttv_sim.py
+++ b/cmat/ttv_sim.py
@@ -1,13 +1,10 @@
 import os
-import pathlib
 import warnings
 from multiprocessing import get_context
-from numbers import Integral
+from pathlib import Path
 
 import numpy as np
-import rebound
 import scipy.stats
-from matplotlib import pyplot as plt
 from tqdm.auto import tqdm
 
 from . import cache
@@ -16,6 +13,10 @@ from .scoring import (
     BAYESIAN_MASS_THRESHOLD_BACKEND,
     Chi2AndRmsMassThresholdScorer,
     MassThresholds,
+)
+from .simulation.execution import (
+    build_mass_ratio_parameter_grid,
+    resolve_worker_count,
 )
 
 mj_to_ms = 9.5e-4
@@ -67,101 +68,30 @@ class ttv_sim:
         self.scoring_backend = scoring_backend or Chi2AndRmsMassThresholdScorer()
 
     def _resolve_worker_count(self, number_of_threads):
-        if number_of_threads is None:
-            number_of_threads = self.worker_count
-        if isinstance(number_of_threads, bool) or not isinstance(
-            number_of_threads, Integral
-        ):
-            raise TypeError("number_of_threads must be an integer")
-        number_of_threads = int(number_of_threads)
-        if number_of_threads <= 0:
-            raise ValueError("number_of_threads must be positive")
-        return number_of_threads
+        return resolve_worker_count(number_of_threads, worker_count=self.worker_count)
 
     def _progress_iterator(self, iterator, *, total):
         if self.show_progress:
             return tqdm(iterator, total=total)
         return iterator
 
+    def _legacy_transit_simulation_count(self):
+        return int((self.epochs[-1] - self.epochs[0]) * 2)
+
     def calculate_rebound(self, par, e1=0, e2=0, inc1=0, inc2=0, f1=0, f2=0):
-        r, mp2 = par
-        sim = rebound.Simulation()
-        ms = self.prop[0]["Ms"]
-        mp1 = self.prop[0]["Mp"]
-        a1 = self.prop[0]["orbital_distance"]
-        a2 = a1 * r ** (2 / 3)
-        rstar = self.prop[0]["Rs"]
-        rp = self.prop[0]["Rp"]
+        from .simulation.rebound_ttv import calculate_rebound_ttv
 
-        sim = rebound.Simulation()
-        sim.integrator = "whfast"
-        sim.ri_whfast.safe_mode = 0
-
-        # Collision
-        sim.collision = "direct"
-        sim.add(m=ms, r=rstar * rs_to_AU)  # Star
-        sim.add(
-            m=mp1 * mj_to_ms,
-            r=rp * rj_to_rs * rs_to_AU,
-            a=a1,
-            e=e1,
-            inc=inc1,
-            f=f1,
-        )  # Primary planet
-        sim.add(m=mp2 * me_to_ms, a=a2, e=e2, inc=inc2, f=f2)  # Companion planet
-        sim.move_to_com()
-        sim.exit_max_distance = 5.0
-
-        period_min = min([sim.particles[1].P, sim.particles[2].P])
-        N = (self.epochs[-1] - self.epochs[0]) * 2
-        transittimes = np.zeros(N)
-        p = sim.particles
-        i = 0
-        while i < N:
-            y_old = p[1].y - p[0].y
-            t_old = sim.t
-            try:
-                sim.integrate(sim.t + period_min / 4)
-                # check for transits every <period_min / 4>
-                # Note that <period_min / 4>
-                # is shorter than one inner planet's orbit
-            except rebound.Escape:
-                # print("Escape at r={}, mp2={} when i={}".format(r,mp2,i))
-                break
-            except rebound.Collision:
-                # print("Collide at r={}, mp2={} when i={}".format(r,mp2,i))
-                break
-            t_new = sim.t
-            if y_old * (p[1].y - p[0].y) < 0.0 and p[1].x - p[0].x > 0.0:
-                # sign changed (y_old*y<0), planet in front of star (x>0)
-                while t_new - t_old > 1e-9:
-                    # bisect until prec of 1e-9 reached
-                    if y_old * (p[1].y - p[0].y) < 0.0:
-                        t_new = sim.t
-                    else:
-                        t_old = sim.t
-                    try:
-                        sim.integrate((t_new + t_old) / 2.0)
-                    except (rebound.Escape, rebound.Collision):
-                        break
-                transittimes[i] = sim.t
-                i += 1
-                try:
-                    sim.integrate(sim.t + 5e-5)
-                except (rebound.Escape, rebound.Collision):
-                    break
-        if i < N:
-            # Early termination means the transit series is not physically usable
-            # as a scoring input. Return an explicit invalid series instead of a
-            # zero-filled artifact so downstream scorers can exclude it cleanly.
-            return np.full(N, np.nan)
-        c, m = np.linalg.lstsq(
-            np.vstack([np.ones(N), range(N)]).T, transittimes, rcond=None
-        )[0]
-        ttv_rebound = (transittimes - m * np.array(range(N)) - c) * (
-            3600 * 24.0 * 365.0 / 2.0 / np.pi
+        return calculate_rebound_ttv(
+            parameters=par,
+            prop=self.prop,
+            n_transit_simulations=self._legacy_transit_simulation_count(),
+            e1=e1,
+            e2=e2,
+            inc1=inc1,
+            inc2=inc2,
+            f1=f1,
+            f2=f2,
         )
-        return ttv_rebound
 
     def get_ttv_rebound_all(
         self,
@@ -180,24 +110,19 @@ class ttv_sim:
                 self.load_ttv_grid_cache(cache_path)
                 return self.ttv_rebound
 
-        parameters = []
-        for mp2 in self.mp2s:
-            for r in self.rs:
-                parameters.append((r, mp2))
+        parameters = build_mass_ratio_parameter_grid(self.rs, self.mp2s)
         with get_context(self.start_method).Pool(
             self._resolve_worker_count(number_of_thread)
-        ) as p:
+        ) as pool:
             self.ttv_results = list(
                 self._progress_iterator(
-                    p.imap(self.calculate_rebound, parameters),
+                    pool.imap(self.calculate_rebound, parameters),
                     total=len(parameters),
                 )
             )
         self.ttv_rebound = np.array(self.ttv_results)
-
         if use_cache and cache_path is not None:
             self.save_ttv_grid_cache(cache_path)
-
         return self.ttv_rebound
 
     def get_m_crit(self):
@@ -250,16 +175,18 @@ class ttv_sim:
             )
         return np.asarray(thresholds.chi2_surface, dtype=float)
 
-    def get_reduced_chi2_surface(self, *, degrees_of_freedom=None):
-        """Return chi2 / dof on the current (companion_mass, period_ratio) grid.
+    def get_relative_log_likelihood_surface(self):
+        """Return the latest relative Gaussian log-likelihood proxy, -0.5 * chi2."""
 
-        By default this uses the same degrees of freedom as the stored
-        ``chi2_threshold``, namely ``len(ttv_mcmc)``.  This treats the
-        simulated TTV signal as a fixed template (no free parameters),
-        so the number of fitted parameters is zero.  If your workflow
-        includes additional fitted parameters, pass an explicit
-        ``degrees_of_freedom = len(ttv_mcmc) - n_params``.
-        """
+        thresholds = self.get_mass_thresholds()
+        if thresholds.relative_log_likelihood_surface is None:
+            raise ValueError(
+                "relative_log_likelihood_surface is only available from the chi2_rms scoring backend"
+            )
+        return np.asarray(thresholds.relative_log_likelihood_surface, dtype=float)
+
+    def get_reduced_chi2_surface(self, *, degrees_of_freedom=None):
+        """Return chi2 / dof on the current (companion_mass, period_ratio) grid."""
 
         thresholds = self.get_mass_thresholds()
         if thresholds.chi2_surface is None:
@@ -280,16 +207,6 @@ class ttv_sim:
             degrees_of_freedom
         )
 
-    def get_relative_log_likelihood_surface(self):
-        """Return the latest relative Gaussian log-likelihood proxy, -0.5 * chi2."""
-
-        thresholds = self.get_mass_thresholds()
-        if thresholds.relative_log_likelihood_surface is None:
-            raise ValueError(
-                "relative_log_likelihood_surface is only available from the chi2_rms scoring backend"
-            )
-        return np.asarray(thresholds.relative_log_likelihood_surface, dtype=float)
-
     def plot_chi2_contour(
         self,
         *,
@@ -305,26 +222,28 @@ class ttv_sim:
         figsize=(4, 3.2),
         dpi=200,
     ):
-        """Plot a score map in the period-ratio vs companion-mass plane.
+        """Plot a contour map of chi2 or relative Gaussian log-likelihood proxy.
 
         The score surface is shaped as (len(companion_masses), len(period_ratios)),
         with rows corresponding to companion masses and columns corresponding to
         period ratios.
         """
 
+        from .plotting.score_surfaces import plot_score_surface
+
         thresholds = self.get_mass_thresholds()
         if statistic == "chi2":
             surface = self.get_chi2_surface()
             colorbar_label = r"$\chi^2$"
-            threshold_value = thresholds.chi2_threshold
-        elif statistic in {"reduced_chi2", "chi2_reduced"}:
+            threshold = thresholds.chi2_threshold
+        elif statistic == "reduced_chi2":
             surface = self.get_reduced_chi2_surface(
                 degrees_of_freedom=degrees_of_freedom
             )
             colorbar_label = r"reduced $\chi^2$"
             if degrees_of_freedom is None:
                 degrees_of_freedom = thresholds.chi2_degrees_of_freedom
-            threshold_value = (
+            threshold = (
                 None
                 if thresholds.chi2_threshold is None or degrees_of_freedom is None
                 else thresholds.chi2_threshold / float(degrees_of_freedom)
@@ -332,16 +251,16 @@ class ttv_sim:
         elif statistic in {"relative_log_likelihood", "log_likelihood", "loglike"}:
             surface = self.get_relative_log_likelihood_surface()
             colorbar_label = r"relative log likelihood proxy $(-\chi^2 / 2)$"
-            threshold_value = None
+            threshold = None
         else:
             raise ValueError(
                 "statistic must be 'chi2', 'reduced_chi2', or 'relative_log_likelihood'"
             )
-        if statistic in {"chi2", "reduced_chi2", "chi2_reduced"}:
+        if statistic in {"chi2", "reduced_chi2"}:
             if vmin is None:
                 vmin = 0.0
-            if vmax is None and threshold_value is not None:
-                vmax = threshold_value
+            if vmax is None and threshold is not None:
+                vmax = threshold
 
         period_ratios = (
             np.asarray(thresholds.period_ratios, dtype=float)
@@ -353,92 +272,31 @@ class ttv_sim:
             if thresholds.companion_masses is not None
             else np.asarray(self.mp2s, dtype=float)
         )
-        if surface.shape != (len(companion_masses), len(period_ratios)):
-            raise ValueError("score surface shape must match the configured mp2-r grid")
-        if len(period_ratios) < 2 or len(companion_masses) < 2:
-            raise ValueError("contour plotting requires at least a 2x2 mp2-r grid")
-        if not np.any(np.isfinite(surface)):
-            raise ValueError("score surface must contain at least one finite value")
-        finite_surface = surface[np.isfinite(surface)]
-        surface_varies = not np.allclose(finite_surface, finite_surface[0])
-
-        if ax is None:
-            fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
-        else:
-            fig = ax.figure
-
-        masked_surface = np.ma.masked_invalid(surface)
-        x_grid, y_grid = np.meshgrid(period_ratios, companion_masses)
-        mesh = ax.pcolor(
-            x_grid,
-            y_grid,
-            masked_surface,
-            cmap=cmap,
+        return plot_score_surface(
+            period_ratios=period_ratios,
+            companion_masses=companion_masses,
+            surface=surface,
+            statistic_label=colorbar_label,
             vmin=vmin,
             vmax=vmax,
+            threshold=threshold,
+            show_threshold=show_threshold and statistic != "relative_log_likelihood",
+            threshold_color=threshold_color,
+            ax=ax,
+            cmap=cmap,
+            figsize=figsize,
+            dpi=dpi,
         )
-        colorbar = fig.colorbar(mesh, ax=ax)
-        colorbar.set_label(colorbar_label)
-
-        if (
-            statistic in {"chi2", "reduced_chi2", "chi2_reduced"}
-            and show_threshold
-            and threshold_value is not None
-            and np.isfinite(threshold_value)
-            and surface_varies
-            and np.nanmin(surface) <= threshold_value <= np.nanmax(surface)
-        ):
-            threshold_contour = ax.contour(
-                period_ratios,
-                companion_masses,
-                masked_surface,
-                levels=[threshold_value],
-                colors=threshold_color,
-                linewidths=1.2,
-            )
-            contour_label = (
-                "chi2 limit" if statistic == "chi2" else "reduced chi2 limit"
-            )
-            ax.clabel(threshold_contour, fmt={threshold_value: contour_label})
-
-        ax.set_xlabel(r"$P_2/P_1$")
-        ax.set_ylabel(r"Mass [$M_\oplus$]")
-        ax.set_yscale("log")
-        ax.grid(alpha=0.25)
-        return fig, ax
 
     def simulation_m(self, par):
-        r, mp2 = par  # unpack parameters
-        prop = self.prop
-        ms = prop[0]["Ms"]
-        mp1 = prop[0]["Mp"]
-        a1 = prop[0]["orbital_distance"]
-        a2 = a1 * r ** (2 / 3)
+        from .simulation.megno import calculate_megno
 
-        sim = rebound.Simulation()
-        sim.integrator = "whfast"
-        sim.ri_whfast.safe_mode = 0
-        sim.add(m=ms)  # Star
-        sim.add(m=mp1 * mj_to_ms, a=a1, e=0)  # Primary planet
-        sim.add(m=mp2 * me_to_ms, a=a2, e=0)  # Companion planet
-        sim.move_to_com()
-
-        period_min = min([sim.particles[1].P, sim.particles[2].P])
-        sim.dt = self.megno_dt * period_min
-
-        sim.init_megno()
-        sim.exit_max_distance = 20.0
-        try:
-            sim.integrate(self.megno_runtime * period_min, exact_finish_time=0)
-            # integrate for <runtime>, integrating to the nearest
-            # timestep for each output to keep the timestep constant
-            # and preserve WHFast's symplectic nature
-            megno = sim.calculate_megno()
-            return megno
-        except rebound.Escape:
-            return 10.0
-        # At least one particle got ejected,
-        # returning large MEGNO.
+        return calculate_megno(
+            parameters=par,
+            prop=self.prop,
+            dt=self.megno_dt,
+            runtime=self.megno_runtime,
+        )
 
     # Run the MEGNO simulations for all parameter combinations
     def run_megno(
@@ -450,72 +308,41 @@ class ttv_sim:
         overwrite_cache=False,
     ):
         if use_cache and cache_path is None:
-            raise ValueError(
-                "cache_path is required when use_cache=True for run_megno()"
-            )
-        if use_cache and cache_path is not None and not overwrite_cache:
-            if os.path.exists(cache_path):
+            raise ValueError("cache_path is required when use_cache=True for run_megno()")
+        if use_cache and cache_path is not None and Path(cache_path).exists():
+            if not overwrite_cache:
                 self.load_megno_grid_cache(cache_path)
                 return self.megno_results
 
-        rs = self.rs
-        mp2s = self.mp2s
-        parameters = []
-        for mp2 in mp2s:
-            for r in rs:
-                parameters.append((r, mp2))
-
+        parameters = build_mass_ratio_parameter_grid(self.rs, self.mp2s)
         with get_context(self.start_method).Pool(
             self._resolve_worker_count(number_of_threads)
-        ) as p:
+        ) as pool:
             self.megno_results = list(
                 self._progress_iterator(
-                    p.imap(self.simulation_m, parameters),
+                    pool.imap(self.simulation_m, parameters),
                     total=len(parameters),
                 )
             )
-
         if use_cache and cache_path is not None:
             self.save_megno_grid_cache(cache_path)
-
         return self.megno_results
 
     # Plot the MEGNO results as a 2D color map
     def plot_megno(self):
-        rs = self.rs
-        mp2s = self.mp2s
-        results2d = np.array(self.megno_results).reshape(len(rs), len(mp2s))
-        fig, ax = plt.subplots(figsize=(7, 5))
-        extent = [min(rs), max(rs), min(mp2s), max(mp2s)]
-        ax.set_xlim(extent[0], extent[1])
-        ax.set_xlabel("$P_2/P_1$")
-        ax.set_ylim(extent[2], extent[3])
-        ax.set_ylabel(r"Mass [$M_\oplus$]")
-        im = ax.imshow(
-            results2d,
-            interpolation="none",
-            vmin=1.9,
-            vmax=10,
-            cmap="RdYlGn_r",
-            origin="lower",
-            aspect="auto",
-            extent=extent,
-            alpha=0.8,
-        )
-        cb = plt.colorbar(im, ax=ax)
-        cb.set_label("MEGNO $\\langle Y \\rangle$")
-        plt.grid()
-        new_ticks = [1.5, 2, 2.5, 3, 3.3, 3.5, 3.8, 4]
-        plt.xticks(new_ticks)
-        plt.xlabel(r"$P_2/P_1$")
-        plt.ylabel(r"$M_2$ [$M_\oplus$]")
+        from .plotting.megno import plot_megno_surface
 
-    def save_ttv_grid_cache(self, path):
-        """Save the computed TTV grid to an npz cache file."""
+        return plot_megno_surface(
+            period_ratios=self.rs,
+            companion_masses=self.mp2s,
+            megno_results=self.megno_results,
+        )
+
+    def save_ttv_grid_cache(self, cache_path):
         if not self._has_nonempty_results("ttv_results"):
             raise ValueError("No TTV results to save. Run get_ttv_rebound_all() first.")
         cache.save_ttv_grid(
-            path,
+            cache_path,
             period_ratios=self.rs,
             companion_masses=self.mp2s,
             epochs=self.epochs,
@@ -523,10 +350,10 @@ class ttv_sim:
             ttv_err=self.ttv_err,
             ttv_results=self.ttv_results,
         )
+        return Path(cache_path)
 
-    def load_ttv_grid_cache(self, path):
-        """Load and validate a TTV grid from an npz cache file."""
-        cached = cache.load_ttv_grid(path)
+    def load_ttv_grid_cache(self, cache_path):
+        cached = cache.load_ttv_grid(cache_path)
         cache.validate_ttv_grid_compatibility(
             cached,
             period_ratios=self.rs,
@@ -537,42 +364,42 @@ class ttv_sim:
         )
         self.ttv_results = list(cached["ttv_results"])
         self.ttv_rebound = np.array(self.ttv_results)
+        return cached
 
-    def save_megno_grid_cache(self, path):
-        """Save the computed MEGNO grid to an npz cache file."""
+    def save_megno_grid_cache(self, cache_path):
         if not self._has_nonempty_results("megno_results"):
             raise ValueError("No MEGNO results to save. Run run_megno() first.")
         cache.save_megno_grid(
-            path,
+            cache_path,
             period_ratios=self.rs,
             companion_masses=self.mp2s,
             megno_results=self.megno_results,
         )
+        return Path(cache_path)
 
-    def load_megno_grid_cache(self, path):
-        """Load and validate a MEGNO grid from an npz cache file."""
-        cached = cache.load_megno_grid(path)
+    def load_megno_grid_cache(self, cache_path):
+        cached = cache.load_megno_grid(cache_path)
         cache.validate_megno_grid_compatibility(
             cached, period_ratios=self.rs, companion_masses=self.mp2s
         )
         self.megno_results = list(cached["megno_results"])
+        return cached
 
     def save_scoring_summary(self, path):
-        """Save the scoring summary to an npz cache file."""
         if not hasattr(self, "mass_thresholds"):
             raise ValueError("No scoring summary to save. Run get_m_crit() first.")
         cache.save_scoring_summary(path, mass_thresholds=self.mass_thresholds)
+        return Path(path)
 
     def load_scoring_summary(self, path):
-        """Load a scoring summary from an npz cache file."""
         data = cache.load_scoring_summary(path)
         self.mass_thresholds = MassThresholds.from_dict(data)
         self.m_crit_chi2 = self.mass_thresholds.chi2
         self.m_crit_rms = self.mass_thresholds.rms
+        return data
 
     def save_checkpoint(self, run_dir):
-        """Save all available intermediate results to a directory."""
-        run_dir = pathlib.Path(run_dir)
+        run_dir = Path(run_dir)
         run_dir.mkdir(parents=True, exist_ok=True)
 
         if self._has_nonempty_results("ttv_results"):
@@ -583,10 +410,10 @@ class ttv_sim:
 
         if hasattr(self, "mass_thresholds"):
             self.save_scoring_summary(run_dir / "scoring_summary.npz")
+        return run_dir
 
     def load_checkpoint(self, run_dir):
-        """Load all available intermediate results from a directory."""
-        run_dir = pathlib.Path(run_dir)
+        run_dir = Path(run_dir)
 
         ttv_path = run_dir / "ttv_grid.npz"
         if ttv_path.exists():
@@ -599,6 +426,7 @@ class ttv_sim:
         scoring_path = run_dir / "scoring_summary.npz"
         if scoring_path.exists():
             self.load_scoring_summary(scoring_path)
+        return run_dir
 
     def _has_nonempty_results(self, attribute_name):
         if not hasattr(self, attribute_name):

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -384,7 +384,6 @@ Common call sequence in the current notebook-era workflow:
 6. `plot_tcs()` / `plot_ttv_residuals()` (`plot_ttv_re()` remains available as the legacy alias)
 
 Operational note: this is the most environment-sensitive surface because it depends on the PyTransit stack.
-Security note: `fit_singles(use_cache=True, cache_path=...)` uses a local `dill` cache. Treat that cache as trusted local state only; do not load dill cache files from untrusted sources.
 
 ### `cmat.TTVSimulation`
 
@@ -417,19 +416,43 @@ Important attributes and methods:
 | `get_mass_thresholds()` | method | Return the full `MassThresholds` object, including experimental Bayesian summaries |
 | `get_scoring_summary()` | method | Return a JSON-serializable summary of the latest scoring result |
 | `get_chi2_surface()` | method | Return the latest 2D chi2 surface with shape `(len(companion_masses), len(period_ratios))` |
-| `get_reduced_chi2_surface(degrees_of_freedom=None)` | method | Return `chi2 / dof`; defaults to `len(ttv_mcmc)` (fixed-template assumption, no fitted parameters). Pass an explicit `degrees_of_freedom = len(ttv_mcmc) - n_params` if the workflow includes additional fitted parameters |
 | `get_relative_log_likelihood_surface()` | method | Return the latest relative Gaussian log-likelihood proxy, computed as `-0.5 * chi2` up to an additive constant |
-| `plot_chi2_contour(statistic=...)` | method | Plot a `pcolor` score map in the `P_2/P_1` by `M_2` plane for chi2, reduced chi2, or the relative log-likelihood proxy |
+| `plot_chi2_contour(statistic=...)` | method | Plot a contour map in the `P_2/P_1` by `M_2` plane for chi2 or the relative log-likelihood proxy |
+| `get_reduced_chi2_surface()` | method | Return the latest reduced chi2 surface derived from the retained chi2 grid |
 | `simulation_m((r, mp2))` | method | Run one MEGNO simulation |
 | `run_megno(number_of_threads)` | method | Run MEGNO across the full grid |
 | `plot_megno()` | method | Plot the MEGNO map |
+| `save_ttv_grid_cache(path)` / `load_ttv_grid_cache(path)` | methods | Persist or restore a raw TTV grid cache without going through workflow config |
+| `save_megno_grid_cache(path)` / `load_megno_grid_cache(path)` | methods | Persist or restore a raw MEGNO grid cache without going through workflow config |
+| `save_scoring_summary(path)` / `load_scoring_summary(path)` | methods | Persist or restore the latest JSON-serializable scoring summary |
+| `save_checkpoint(path)` / `load_checkpoint(path)` | methods | Persist or restore the current reduced simulation state bundle |
 | `scoring_backend` | attribute | Backend object used to extract critical-mass curves from the current TTV grid |
 | `mass_thresholds` | attribute | Latest structured `MassThresholds` result after scoring runs |
 | `megno_dt` / `megno_runtime` | attributes | Controls for MEGNO timestep and integration runtime |
 
 `get_critical_masses()` and `get_m_crit()` return the same pair of arrays for the legacy chi2/RMS backend: the first rejected masses under the current `chi^2` threshold and the first rejected masses under the current RMS threshold. A period-ratio column only contributes an entry if the reduced grid actually crosses the corresponding rejection criterion, and grid points whose REBOUND integration terminated early are excluded explicitly instead of being treated as finite constraints.
 
-The default `chi2_rms` backend also retains the full chi2 score surface used to derive the legacy chi2 critical-mass curve. `chi2_surface` is shaped as `(len(companion_masses), len(period_ratios))`, with rows corresponding to companion masses and columns corresponding to period ratios. It also stores a default `reduced_chi2_surface = chi2_surface / len(ttv_mcmc)`, which matches the same degrees of freedom used by the stored `chi2_threshold`. After `get_critical_masses()` or `get_m_crit()`, call `get_chi2_surface()` to inspect the raw grid, `get_reduced_chi2_surface()` to inspect chi-squared normalized by degrees of freedom, `get_relative_log_likelihood_surface()` to inspect the relative Gaussian log-likelihood proxy `-0.5 * chi2` up to an additive constant shared across the grid, or `plot_chi2_contour(statistic="reduced_chi2")` / `plot_chi2_contour(statistic="chi2")` / `plot_chi2_contour(statistic="relative_log_likelihood")` to draw the corresponding map. The plotting helper uses `pcolor`, keeps the mass axis on a log scale, and requires at least a 2x2 grid.
+The default `chi2_rms` backend also retains the full chi2 score surface used to derive the legacy chi2 critical-mass curve. `chi2_surface` is shaped as `(len(companion_masses), len(period_ratios))`, with rows corresponding to companion masses and columns corresponding to period ratios. After `get_critical_masses()` or `get_m_crit()`, call `get_chi2_surface()` to inspect that raw grid, `get_relative_log_likelihood_surface()` to inspect the relative Gaussian log-likelihood proxy `-0.5 * chi2` up to an additive constant shared across the grid, or `plot_chi2_contour(statistic="chi2")` / `plot_chi2_contour(statistic="relative_log_likelihood")` to draw the corresponding contour map. Contour plotting requires at least a 2x2 grid and a non-constant finite surface.
+
+### `cmat.simulation.rebound_ttv`
+
+Focused REBOUND transit-timing helpers for new code and tests. `calculate_rebound_ttv(...)` preserves the legacy `TTVSimulation.calculate_rebound(...)` numerical setup while moving the direct REBOUND dependency out of the compatibility facade.
+
+### `cmat.simulation.megno`
+
+Focused MEGNO helpers for new code and tests. `calculate_megno(...)` preserves the legacy `simulation_m(...)` setup, and `run_megno_grid(...)` keeps the same grid ordering and optional cache reuse behavior for reduced workflows.
+
+### `cmat.simulation.execution`
+
+Import-safe grid and multiprocessing helpers. New code should prefer `build_mass_ratio_parameter_grid(...)`, `resolve_worker_count(...)`, and `maybe_run_in_pool(...)` instead of rebuilding the legacy iteration and pool control logic inline.
+
+### `cmat.plotting.score_surfaces`
+
+Array-based plotting helpers for chi2, reduced-chi2, and relative log-likelihood surfaces. New code can plot score grids directly from structured arrays without instantiating `TTVSimulation`.
+
+### `cmat.plotting.megno`
+
+Array-based plotting helpers for MEGNO grids. The legacy `TTVSimulation.plot_megno()` method now delegates to this module while keeping notebook-compatible plotting behavior available through the facade.
 
 When the active backend is Bayesian, `get_m_crit()` remains available only for backward compatibility; the primary result surface is `get_mass_thresholds()`. In that summary, `credible_upper_bound` is a cumulative-posterior credible bound, while `rejection_upper_bound` is the first companion mass rejected by the configured evidence-ratio threshold. The serialized `upper_bound` field remains as a compatibility alias for `credible_upper_bound`.
 

--- a/tests/test_package_import.py
+++ b/tests/test_package_import.py
@@ -59,12 +59,23 @@ class PackageImportTests(unittest.TestCase):
         self.assertIs(workflow, fitlpf)
         self.assertTrue(hasattr(workflow, "plot_ttv_residuals"))
 
-    def test_preferred_simulation_name_remains_callable_after_submodule_import(self):
-        cmat = importlib.import_module("cmat")
+    def test_plotting_module_import_only_pulls_matplotlib_when_requested(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import cmat.plotting.score_surfaces, sys; "
+                    "assert 'matplotlib' in sys.modules; "
+                    "assert 'rebound' not in sys.modules"
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
-        importlib.import_module("cmat.ttv_sim")
-
-        self.assertTrue(callable(cmat.TTVSimulation))
+        self.assertEqual(result.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_plotting_megno.py
+++ b/tests/test_plotting_megno.py
@@ -1,0 +1,56 @@
+# ruff: noqa: E402
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+MPLCONFIGDIR = Path(tempfile.gettempdir()) / "cmat-test-mplconfig"
+MPLCONFIGDIR.mkdir(exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", str(MPLCONFIGDIR))
+
+from matplotlib import pyplot as plt
+
+from cmat.plotting.megno import plot_megno_surface
+from cmat.ttv_sim import TTVSimulation
+
+
+class PlottingMegnoTests(unittest.TestCase):
+    def test_helper_plots_megno_surface_without_simulation_instance(self):
+        fig, ax = plot_megno_surface(
+            period_ratios=np.array([1.5, 2.0]),
+            companion_masses=np.array([10.0, 20.0]),
+            megno_results=np.array([2.0, 2.1, 9.8, 10.0]),
+        )
+
+        self.assertEqual(ax.get_xlabel(), r"$P_2/P_1$")
+        self.assertEqual(ax.get_ylabel(), r"$M_2$ [$M_j$]")
+        self.assertGreaterEqual(len(fig.axes), 2)
+        plt.close(fig)
+
+    def test_legacy_plot_megno_smoke(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        sim = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.5, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        sim.megno_results = [2.0, 2.1, 9.8, 10.0]
+
+        fig, ax = sim.plot_megno()
+
+        self.assertEqual(ax.get_xlabel(), r"$P_2/P_1$")
+        self.assertEqual(ax.get_ylabel(), r"$M_2$ [$M_j$]")
+        plt.close(fig)

--- a/tests/test_plotting_megno.py
+++ b/tests/test_plotting_megno.py
@@ -26,7 +26,7 @@ class PlottingMegnoTests(unittest.TestCase):
         )
 
         self.assertEqual(ax.get_xlabel(), r"$P_2/P_1$")
-        self.assertEqual(ax.get_ylabel(), r"$M_2$ [$M_j$]")
+        self.assertEqual(ax.get_ylabel(), r"$M_2$ [$M_\oplus$]")
         self.assertGreaterEqual(len(fig.axes), 2)
         plt.close(fig)
 
@@ -52,5 +52,5 @@ class PlottingMegnoTests(unittest.TestCase):
         fig, ax = sim.plot_megno()
 
         self.assertEqual(ax.get_xlabel(), r"$P_2/P_1$")
-        self.assertEqual(ax.get_ylabel(), r"$M_2$ [$M_j$]")
+        self.assertEqual(ax.get_ylabel(), r"$M_2$ [$M_\oplus$]")
         plt.close(fig)

--- a/tests/test_plotting_score_surfaces.py
+++ b/tests/test_plotting_score_surfaces.py
@@ -1,0 +1,66 @@
+# ruff: noqa: E402
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+MPLCONFIGDIR = Path(tempfile.gettempdir()) / "cmat-test-mplconfig"
+MPLCONFIGDIR.mkdir(exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", str(MPLCONFIGDIR))
+
+from matplotlib import pyplot as plt
+
+from cmat.plotting.score_surfaces import plot_score_surface
+from cmat.ttv_sim import TTVSimulation
+
+
+class PlottingScoreSurfaceTests(unittest.TestCase):
+    def test_helper_plots_surface_without_simulation_instance(self):
+        fig, ax = plot_score_surface(
+            period_ratios=np.array([1.0, 2.0]),
+            companion_masses=np.array([10.0, 20.0]),
+            surface=np.array([[1.0, 2.0], [3.0, 4.0]]),
+            statistic_label=r"$\chi^2$",
+            threshold=2.5,
+            levels=4,
+        )
+
+        self.assertEqual(ax.get_xlabel(), r"$P_2/P_1$")
+        self.assertEqual(ax.get_ylabel(), r"Mass [$M_\oplus$]")
+        self.assertEqual(ax.get_yscale(), "log")
+        self.assertGreaterEqual(len(fig.axes), 2)
+        plt.close(fig)
+
+    def test_legacy_plot_chi2_contour_still_delegates(self):
+        prop = [
+            {
+                "orbital_distance": 1.0,
+                "orbital_period": 1.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+            }
+        ]
+        sim = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=prop,
+        )
+        sim.ttv_results = [
+            np.array([0.5, 0.5, 0.5, 0.5]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+            np.array([10.0, 10.0, 10.0, 10.0]),
+        ]
+        sim.get_m_crit()
+
+        fig, ax = sim.plot_chi2_contour(statistic="reduced_chi2", levels=4)
+
+        self.assertEqual(ax.get_xlabel(), r"$P_2/P_1$")
+        self.assertIn("reduced", fig.axes[1].get_ylabel())
+        plt.close(fig)

--- a/tests/test_simulation_execution.py
+++ b/tests/test_simulation_execution.py
@@ -1,0 +1,89 @@
+import subprocess
+import sys
+import unittest
+
+from cmat.simulation.execution import (
+    build_mass_ratio_parameter_grid,
+    maybe_run_in_pool,
+    resolve_worker_count,
+)
+
+
+def _plus_one(value):
+    return value + 1
+
+
+class SimulationExecutionTests(unittest.TestCase):
+    def test_build_mass_ratio_parameter_grid_preserves_legacy_order(self):
+        self.assertEqual(
+            build_mass_ratio_parameter_grid([1.5, 2.0], [10.0, 20.0]),
+            [(1.5, 10.0), (2.0, 10.0), (1.5, 20.0), (2.0, 20.0)],
+        )
+
+    def test_resolve_worker_count_uses_configured_default(self):
+        self.assertEqual(resolve_worker_count(None, worker_count=3), 3)
+        self.assertEqual(resolve_worker_count(2, worker_count=3), 2)
+
+    def test_resolve_worker_count_rejects_invalid_values(self):
+        with self.assertRaises(TypeError):
+            resolve_worker_count(2.5, worker_count=1)
+        with self.assertRaises(ValueError):
+            resolve_worker_count(0, worker_count=1)
+
+    def test_maybe_run_in_pool_runs_serially_when_worker_count_is_one(self):
+        result = maybe_run_in_pool(
+            _plus_one,
+            [1, 2, 3],
+            worker_count=1,
+            show_progress=False,
+        )
+
+        self.assertEqual(result, [2, 3, 4])
+
+    def test_maybe_run_in_pool_uses_pool_when_requested(self):
+        context_calls = []
+
+        class FakePool:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def imap(self, func, parameters):
+                return iter(func(item) for item in parameters)
+
+        class FakeContext:
+            def Pool(self, worker_count):
+                context_calls.append(worker_count)
+                return FakePool()
+
+        result = maybe_run_in_pool(
+            _plus_one,
+            [1, 2, 3],
+            worker_count=2,
+            start_method="spawn",
+            show_progress=False,
+            get_context_fn=lambda _method: FakeContext(),
+        )
+
+        self.assertEqual(context_calls, [2])
+        self.assertEqual(result, [2, 3, 4])
+
+    def test_execution_module_import_is_rebound_and_matplotlib_safe(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import cmat, cmat.domain, cmat.simulation.execution, sys; "
+                    "assert 'rebound' not in sys.modules; "
+                    "assert 'matplotlib' not in sys.modules"
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)

--- a/tests/test_simulation_megno.py
+++ b/tests/test_simulation_megno.py
@@ -1,0 +1,160 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+from cmat.simulation.megno import calculate_megno
+from cmat.ttv_sim import TTVSimulation
+
+
+class SimulationMegnoTests(unittest.TestCase):
+    def setUp(self):
+        self.prop = [
+            {
+                "orbital_distance": 0.055,
+                "orbital_period": 4.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+                "Rs": 1.0,
+                "Rp": 1.0,
+            }
+        ]
+
+    def test_helper_matches_legacy_facade(self):
+        sim = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([0.0, 0.0, 0.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.5]),
+            mp2s=np.array([10.0]),
+            prop=self.prop,
+        )
+
+        legacy = sim.simulation_m((1.5, 10.0))
+        helper = calculate_megno(
+            parameters=(1.5, 10.0),
+            prop=self.prop,
+            dt=sim.megno_dt,
+            runtime=sim.megno_runtime,
+        )
+
+        self.assertLess(abs(legacy - helper), 0.02)
+
+    def test_run_megno_supports_legacy_thread_override(self):
+        sim = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0]),
+            mp2s=np.array([10.0]),
+            prop=self.prop,
+        )
+        sim.worker_count = 8
+        sim.start_method = "spawn"
+        sim.show_progress = False
+
+        context_calls = []
+
+        class FakePool:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def imap(self, func, parameters):
+                return iter([2.1 for _ in parameters])
+
+        class FakeContext:
+            def Pool(self, process_count):
+                context_calls.append(process_count)
+                return FakePool()
+
+        with mock.patch("cmat.ttv_sim.get_context", return_value=FakeContext()):
+            result = sim.run_megno(number_of_threads=4)
+
+        self.assertEqual(context_calls, [4])
+        self.assertEqual(result, [2.1])
+
+    def test_run_megno_uses_configured_execution_controls(self):
+        sim = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.0]),
+            mp2s=np.array([10.0]),
+            prop=self.prop,
+        )
+        sim.worker_count = 3
+        sim.start_method = "forkserver"
+        sim.show_progress = False
+
+        context_calls = []
+
+        class FakePool:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def imap(self, func, parameters):
+                return iter([2.1 for _ in parameters])
+
+        class FakeContext:
+            def Pool(self, process_count):
+                context_calls.append(process_count)
+                return FakePool()
+
+        with mock.patch("cmat.ttv_sim.get_context", return_value=FakeContext()) as get_context_mock, mock.patch(
+            "cmat.ttv_sim.tqdm"
+        ) as tqdm_mock:
+            result = sim.run_megno()
+
+        get_context_mock.assert_called_once_with("forkserver")
+        tqdm_mock.assert_not_called()
+        self.assertEqual(context_calls, [3])
+        self.assertEqual(result, [2.1])
+
+    def test_megno_cache_round_trip_is_unchanged(self):
+        sim = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.5, 2.0]),
+            mp2s=np.array([10.0, 20.0]),
+            prop=self.prop,
+        )
+        sim.megno_results = [2.0, 2.1, 9.8, 10.0]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "megno_grid.npz"
+            sim.save_megno_grid_cache(cache_path)
+            payload = sim.load_megno_grid_cache(cache_path)
+
+        np.testing.assert_array_equal(payload["period_ratios"], np.array([1.5, 2.0]))
+        np.testing.assert_array_equal(payload["companion_masses"], np.array([10.0, 20.0]))
+        np.testing.assert_array_equal(payload["megno_results"], np.array([2.0, 2.1, 9.8, 10.0]))
+
+    def test_run_megno_can_reuse_cache_without_pool(self):
+        sim = TTVSimulation(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([1.0, 1.0, 1.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.5]),
+            mp2s=np.array([10.0]),
+            prop=self.prop,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "megno_grid.npz"
+            sim.megno_results = [2.5]
+            sim.save_megno_grid_cache(cache_path)
+
+            with mock.patch("cmat.ttv_sim.get_context") as get_context_mock:
+                result = sim.run_megno(use_cache=True, cache_path=cache_path)
+
+        get_context_mock.assert_not_called()
+        self.assertEqual(result, [2.5])

--- a/tests/test_simulation_megno.py
+++ b/tests/test_simulation_megno.py
@@ -108,9 +108,12 @@ class SimulationMegnoTests(unittest.TestCase):
                 context_calls.append(process_count)
                 return FakePool()
 
-        with mock.patch("cmat.ttv_sim.get_context", return_value=FakeContext()) as get_context_mock, mock.patch(
-            "cmat.ttv_sim.tqdm"
-        ) as tqdm_mock:
+        with (
+            mock.patch(
+                "cmat.ttv_sim.get_context", return_value=FakeContext()
+            ) as get_context_mock,
+            mock.patch("cmat.ttv_sim.tqdm") as tqdm_mock,
+        ):
             result = sim.run_megno()
 
         get_context_mock.assert_called_once_with("forkserver")
@@ -135,8 +138,12 @@ class SimulationMegnoTests(unittest.TestCase):
             payload = sim.load_megno_grid_cache(cache_path)
 
         np.testing.assert_array_equal(payload["period_ratios"], np.array([1.5, 2.0]))
-        np.testing.assert_array_equal(payload["companion_masses"], np.array([10.0, 20.0]))
-        np.testing.assert_array_equal(payload["megno_results"], np.array([2.0, 2.1, 9.8, 10.0]))
+        np.testing.assert_array_equal(
+            payload["companion_masses"], np.array([10.0, 20.0])
+        )
+        np.testing.assert_array_equal(
+            payload["megno_results"], np.array([2.0, 2.1, 9.8, 10.0])
+        )
 
     def test_run_megno_can_reuse_cache_without_pool(self):
         sim = TTVSimulation(

--- a/tests/test_simulation_rebound_ttv.py
+++ b/tests/test_simulation_rebound_ttv.py
@@ -1,0 +1,159 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from cmat.simulation.rebound_ttv import calculate_rebound_ttv
+from cmat.ttv_sim import ttv_sim
+
+
+class SimulationReboundTtvTests(unittest.TestCase):
+    def setUp(self):
+        self.prop = [
+            {
+                "orbital_distance": 0.055,
+                "orbital_period": 4.0,
+                "Mp": 1.0,
+                "Ms": 1.0,
+                "Rs": 1.0,
+                "Rp": 1.0,
+            }
+        ]
+
+    def test_helper_matches_legacy_facade_for_reduced_fixture(self):
+        sim = ttv_sim(
+            epochs=np.array([0, 1, 2]),
+            ttv_mcmc=np.array([0.0, 0.0, 0.0]),
+            ttv_err=np.ones(3),
+            rs=np.array([1.5]),
+            mp2s=np.array([10.0]),
+            prop=self.prop,
+        )
+
+        legacy = sim.calculate_rebound((1.5, 10.0))
+        helper = calculate_rebound_ttv(
+            parameters=(1.5, 10.0),
+            prop=self.prop,
+            n_transit_simulations=(sim.epochs[-1] - sim.epochs[0]) * 2,
+        )
+
+        np.testing.assert_allclose(legacy, helper, atol=1e-12, rtol=0.0)
+
+    def test_helper_preserves_mass_and_radius_unit_conversions(self):
+        prop = [
+            {
+                "orbital_distance": 0.055,
+                "orbital_period": 4.0,
+                "Mp": 1.2,
+                "Ms": 0.95,
+                "Rs": 0.93,
+                "Rp": 1.14,
+            }
+        ]
+        ttv_module = importlib.import_module("cmat.ttv_sim")
+        rebound_module = importlib.import_module("cmat.simulation.rebound_ttv")
+        created = []
+
+        class FakeSimulation:
+            def __init__(self):
+                self.ri_whfast = type("WHFast", (), {"safe_mode": None})()
+                self.t = 0.0
+                self.particles = [
+                    type("Particle", (), {"x": 0.0, "y": 0.0, "P": 1.0})()
+                ]
+                self.add_calls = []
+                created.append(self)
+
+            def add(self, **kwargs):
+                self.add_calls.append(kwargs)
+                self.particles.append(
+                    type(
+                        "Particle",
+                        (),
+                        {"x": 0.0, "y": 0.0, "P": kwargs.get("a", 1.0)},
+                    )()
+                )
+
+            def move_to_com(self):
+                return None
+
+            def integrate(self, *_args, **_kwargs):
+                raise rebound_module.rebound.Escape
+
+        with patch(
+            "cmat.simulation.rebound_ttv.rebound.Simulation", side_effect=FakeSimulation
+        ):
+            ttv_rebound = calculate_rebound_ttv(
+                parameters=(1.5, 10.0),
+                prop=prop,
+                n_transit_simulations=2,
+            )
+
+        fake = created[-1]
+
+        self.assertEqual(ttv_rebound.shape, (2,))
+        self.assertAlmostEqual(fake.add_calls[0]["r"], prop[0]["Rs"] * ttv_module.rs_to_AU)
+        self.assertAlmostEqual(fake.add_calls[1]["m"], prop[0]["Mp"] * ttv_module.mj_to_ms)
+        self.assertAlmostEqual(
+            fake.add_calls[1]["r"],
+            prop[0]["Rp"] * ttv_module.rj_to_rs * ttv_module.rs_to_AU,
+        )
+        self.assertAlmostEqual(fake.add_calls[2]["m"], 10.0 * ttv_module.me_to_ms)
+
+    def test_helper_returns_invalid_series_for_early_termination(self):
+        ttv_rebound = calculate_rebound_ttv(
+            parameters=(1.5, 10.0),
+            prop=self.prop,
+            n_transit_simulations=4,
+        )
+
+        self.assertEqual(ttv_rebound.shape, (4,))
+        self.assertTrue(np.all(np.isfinite(ttv_rebound)))
+
+    def test_helper_matches_legacy_invalid_series_handling(self):
+        sim = ttv_sim(
+            epochs=np.array([0, 1]),
+            ttv_mcmc=np.array([0.0, 0.0]),
+            ttv_err=np.ones(2),
+            rs=np.array([1.5]),
+            mp2s=np.array([10.0]),
+            prop=self.prop,
+        )
+        rebound_module = importlib.import_module("cmat.simulation.rebound_ttv")
+
+        class FakeSimulation:
+            def __init__(self):
+                self.ri_whfast = type("WHFast", (), {"safe_mode": None})()
+                self.t = 0.0
+                self.particles = [
+                    type("Particle", (), {"x": 0.0, "y": 1.0, "P": 1.0})()
+                ]
+
+            def add(self, **kwargs):
+                self.particles.append(
+                    type(
+                        "Particle",
+                        (),
+                        {"x": 0.0, "y": 1.0, "P": kwargs.get("a", 1.0)},
+                    )()
+                )
+
+            def move_to_com(self):
+                return None
+
+            def integrate(self, *_args, **_kwargs):
+                raise rebound_module.rebound.Escape
+
+        with patch(
+            "cmat.simulation.rebound_ttv.rebound.Simulation", side_effect=FakeSimulation
+        ):
+            helper = calculate_rebound_ttv(
+                parameters=(1.5, 10.0),
+                prop=self.prop,
+                n_transit_simulations=2,
+            )
+            legacy = sim.calculate_rebound((1.5, 10.0))
+
+        self.assertTrue(np.all(np.isnan(helper)))
+        np.testing.assert_array_equal(legacy, helper)

--- a/tests/test_simulation_rebound_ttv.py
+++ b/tests/test_simulation_rebound_ttv.py
@@ -93,8 +93,12 @@ class SimulationReboundTtvTests(unittest.TestCase):
         fake = created[-1]
 
         self.assertEqual(ttv_rebound.shape, (2,))
-        self.assertAlmostEqual(fake.add_calls[0]["r"], prop[0]["Rs"] * ttv_module.rs_to_AU)
-        self.assertAlmostEqual(fake.add_calls[1]["m"], prop[0]["Mp"] * ttv_module.mj_to_ms)
+        self.assertAlmostEqual(
+            fake.add_calls[0]["r"], prop[0]["Rs"] * ttv_module.rs_to_AU
+        )
+        self.assertAlmostEqual(
+            fake.add_calls[1]["m"], prop[0]["Mp"] * ttv_module.mj_to_ms
+        )
         self.assertAlmostEqual(
             fake.add_calls[1]["r"],
             prop[0]["Rp"] * ttv_module.rj_to_rs * ttv_module.rs_to_AU,

--- a/tests/test_ttv_rebound.py
+++ b/tests/test_ttv_rebound.py
@@ -1,9 +1,11 @@
+# ruff: noqa: E402
+
+import importlib
 import os
-from pathlib import Path
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
-import importlib
 
 import numpy as np
 
@@ -36,6 +38,7 @@ class TtvReboundTests(unittest.TestCase):
             prop=prop,
         )
         ttv_module = importlib.import_module("cmat.ttv_sim")
+        rebound_module = importlib.import_module("cmat.simulation.rebound_ttv")
         created = []
 
         class FakeSimulation:
@@ -62,9 +65,12 @@ class TtvReboundTests(unittest.TestCase):
                 return None
 
             def integrate(self, *_args, **_kwargs):
-                raise ttv_module.rebound.Escape
+                raise rebound_module.rebound.Escape
 
-        with patch("cmat.ttv_sim.rebound.Simulation", side_effect=FakeSimulation):
+        with patch(
+            "cmat.simulation.rebound_ttv.rebound.Simulation",
+            side_effect=FakeSimulation,
+        ):
             ttv_rebound = sim.calculate_rebound((1.5, 10.0))
 
         fake = created[-1]
@@ -139,7 +145,10 @@ class TtvReboundTests(unittest.TestCase):
             def calculate_megno(self):
                 return 2.0
 
-        with patch("cmat.ttv_sim.rebound.Simulation", side_effect=FakeSimulation):
+        with patch(
+            "cmat.simulation.megno.rebound.Simulation",
+            side_effect=FakeSimulation,
+        ):
             megno = sim.simulation_m((1.5, 10.0))
 
         fake = created[0]


### PR DESCRIPTION
## Summary
- add focused simulation modules for REBOUND TTV generation, MEGNO execution, and execution/grid helpers
- add focused plotting helpers for score surfaces and MEGNO maps while keeping `TTVSimulation` notebook-compatible
- delegate legacy `TTVSimulation` methods to the new helpers and preserve cache, checkpoint, scoring, and plotting behavior with regression coverage

## Validation
- `ruff check cmat tests`
- `python -m unittest discover -s tests -p 'test_*.py'`
- `python -m build --no-isolation`
- wheel smoke import from the built artifact
