### PR TITLE
Fix Fitlpf.fit_singles dill cache reloads

### DIFF
--- a/cmat/base.py
+++ b/cmat/base.py
@@ -64,6 +64,7 @@ Functions:
 
 import os
 import json
+import pickle
 import pathlib
 import glob
 import warnings
@@ -96,6 +97,7 @@ RJ_TO_RS = 0.102792236
 RS_TO_AU = 0.00464913034
 DAY_TO_SEC = 24 * 60 * 60
 FITLPF_PARAMETER_CACHE_SCHEMA_VERSION = "1"
+FITLPF_SINGLES_CACHE_SCHEMA_VERSION = "2"
 
 
 def get_id(planet_name: str):
@@ -558,13 +560,48 @@ class Fitlpf:
                     UserWarning,
                     stacklevel=2,
                 )
-                with open(cache_path, "rb") as f:
-                    cached_data = dill.load(f)
-                self.singles = cached_data["singles"]
-                self.post_samples = cached_data["post_samples"]
-                self.tcs = cached_data["tcs"]
-                self.epochs = cached_data["epochs"]
-                return
+                try:
+                    with open(cache_path, "rb") as f:
+                        cached_data = dill.load(f)
+                    if not isinstance(cached_data, dict):
+                        raise TypeError(
+                            "fit_singles cache payload must be a dictionary"
+                        )
+                    schema_version = cached_data.get("cache_schema_version")
+                    if schema_version != FITLPF_SINGLES_CACHE_SCHEMA_VERSION:
+                        raise ValueError(
+                            "fit_singles cache schema mismatch: "
+                            f"expected {FITLPF_SINGLES_CACHE_SCHEMA_VERSION!r}, "
+                            f"found {schema_version!r}"
+                        )
+                    cached_planet_name = cached_data.get("planet_name")
+                    if cached_planet_name != self.planet_name:
+                        raise ValueError(
+                            "fit_singles cache planet_name mismatch: "
+                            f"expected {self.planet_name!r}, "
+                            f"found {cached_planet_name!r}"
+                        )
+                    self.post_samples = cached_data["post_samples"]
+                    self.tcs = cached_data["tcs"]
+                    self.epochs = cached_data["epochs"]
+                    self.singles = None
+                    return
+                except (
+                    AttributeError,
+                    EOFError,
+                    ImportError,
+                    ModuleNotFoundError,
+                    KeyError,
+                    TypeError,
+                    ValueError,
+                    pickle.UnpicklingError,
+                ) as exc:
+                    warnings.warn(
+                        "Ignoring fit_singles cache at "
+                        f"{cache_path!r} and recomputing fits: {exc}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
 
         # self.fit_single_v = np.vectorize(self.fit_single)
         # self.singles = self.fit_single_v(np.arange(len(self.lpf.times)))
@@ -586,12 +623,16 @@ class Fitlpf:
         if use_cache and cache_path:
             pathlib.Path(cache_path).parent.mkdir(parents=True, exist_ok=True)
             with open(cache_path, "wb") as f:
-                dill.dump({
-                    "singles": self.singles,
-                    "post_samples": self.post_samples,
-                    "tcs": self.tcs,
-                    "epochs": self.epochs
-                }, f)
+                dill.dump(
+                    {
+                        "cache_schema_version": FITLPF_SINGLES_CACHE_SCHEMA_VERSION,
+                        "planet_name": self.planet_name,
+                        "post_samples": self.post_samples,
+                        "tcs": self.tcs,
+                        "epochs": self.epochs,
+                    },
+                    f,
+                )
 
     def get_posterior_samples(self):
         """

--- a/tests/test_base_cache.py
+++ b/tests/test_base_cache.py
@@ -3,18 +3,72 @@
 import importlib
 import json
 import os
+import sys
 import tempfile
+import types
 import unittest
+import warnings
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
+
+import dill
+import numpy as np
 
 try:
     from cmat.base import Fitlpf
     _HAS_BASE = True
-except Exception:
-    _HAS_BASE = False
+    _BASE_IMPORT_ERROR = None
+except Exception as exc:
+    _BASE_IMPORT_ERROR = exc
+    try:
+        sys.modules.pop("cmat.base", None)
+        sys.modules.pop("cmat.singlefit", None)
 
-_SKIP_REASON = "cmat.base requires pytransit/numba stack unavailable in this environment"
+        pytransit_module = types.ModuleType("pytransit")
+        pytransit_lpf_module = types.ModuleType("pytransit.lpf")
+        pytransit_tesslpf_module = types.ModuleType("pytransit.lpf.tesslpf")
+        pytransit_orbits_module = types.ModuleType("pytransit.orbits")
+
+        class _StubBaseLPF:
+            pass
+
+        class _StubTESSLPF:
+            pass
+
+        def _stub_fold(*args, **kwargs):
+            return np.zeros(1)
+
+        def _stub_downsample_time(*args, **kwargs):
+            return np.zeros(1), np.zeros(1), np.zeros(1)
+
+        def _stub_epoch(tc, zero_epoch, period):
+            return int(np.rint((tc - zero_epoch) / period))
+
+        pytransit_tesslpf_module.BaseLPF = _StubBaseLPF
+        pytransit_tesslpf_module.TESSLPF = _StubTESSLPF
+        pytransit_tesslpf_module.fold = _stub_fold
+        pytransit_tesslpf_module.downsample_time = _stub_downsample_time
+        pytransit_orbits_module.epoch = _stub_epoch
+
+        sys.modules["pytransit"] = pytransit_module
+        sys.modules["pytransit.lpf"] = pytransit_lpf_module
+        sys.modules["pytransit.lpf.tesslpf"] = pytransit_tesslpf_module
+        sys.modules["pytransit.orbits"] = pytransit_orbits_module
+
+        from cmat.base import Fitlpf
+
+        _HAS_BASE = True
+        _BASE_IMPORT_ERROR = None
+    except Exception as fallback_exc:
+        _HAS_BASE = False
+        _BASE_IMPORT_ERROR = fallback_exc
+
+_SKIP_REASON = (
+    "cmat.base requires pytransit/numba stack unavailable in this environment"
+    if _BASE_IMPORT_ERROR is None
+    else f"cmat.base import is unavailable: {_BASE_IMPORT_ERROR}"
+)
 
 _MOCK_PROP = [{
     "transit_time": 1000.0,
@@ -31,6 +85,42 @@ _MOCK_PROP = [{
     "transit_time_unit": "BJD",
     "Mp_ref": "Test Ref",
 }]
+
+
+class _FakeSeries:
+    def __init__(self, mean_value, std_value):
+        self._mean_value = mean_value
+        self._std_value = std_value
+
+    def mean(self):
+        return self._mean_value
+
+    def std(self):
+        return self._std_value
+
+
+class _FakeSingle:
+    def __init__(self, tc_mean, tc_std):
+        self._posterior = {"tc": _FakeSeries(tc_mean, tc_std)}
+
+    def posterior_samples(self):
+        return self._posterior
+
+
+class _DummyProgress:
+    def update(self, _count):
+        return None
+
+
+class _DummyTqdm:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return _DummyProgress()
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
 
 
 @unittest.skipUnless(_HAS_BASE, _SKIP_REASON)
@@ -134,6 +224,169 @@ class DownloadDataCacheTests(unittest.TestCase):
 
             # With overwrite_cache=True, the API should be called
             self.assertEqual(mock_observations.query_object.call_count, 1)
+
+
+@unittest.skipUnless(_HAS_BASE, _SKIP_REASON)
+class FitSinglesCacheTests(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.cache_file = os.path.join(self._tmpdir, "fit_singles.dill")
+
+    def _make_fit(self, planet_name="TestPlanet"):
+        fit = Fitlpf(planet_name)
+        fit.zero_epoch = importlib.import_module("cmat.base").ufloat(100.0, 1e-3)
+        fit.period = importlib.import_module("cmat.base").ufloat(2.0, 1e-4)
+        fit.lpf = SimpleNamespace(times=[object(), object(), object()])
+        return fit
+
+    @staticmethod
+    def _vectorize_factory(func):
+        def _runner(indices, pbar):
+            return np.array([func(index, pbar) for index in indices], dtype=object)
+
+        return _runner
+
+    def _fit_single_side_effect(self, index, _pbar):
+        return _FakeSingle(110.0 + 2.0 * index, 0.01 + 0.01 * index)
+
+    def test_valid_v2_cache_restores_results_without_refitting(self):
+        fit = self._make_fit()
+        payload = {
+            "cache_schema_version": "2",
+            "planet_name": "TestPlanet",
+            "post_samples": [{"tc": _FakeSeries(110.0, 0.01)}],
+            "tcs": [importlib.import_module("cmat.base").ufloat(110.0, 0.01)],
+            "epochs": np.array([5]),
+        }
+
+        with open(self.cache_file, "wb") as f:
+            dill.dump(payload, f)
+
+        with patch.object(fit, "fit_single", side_effect=AssertionError("should not refit")):
+            fit.fit_singles(use_cache=True, cache_path=self.cache_file)
+
+        self.assertIsNone(fit.singles)
+        np.testing.assert_array_equal(fit.epochs, payload["epochs"])
+        self.assertEqual(len(fit.post_samples), 1)
+        self.assertAlmostEqual(fit.post_samples[0]["tc"].mean(), 110.0)
+        self.assertAlmostEqual(fit.post_samples[0]["tc"].std(), 0.01)
+        self.assertAlmostEqual(fit.tcs[0].n, 110.0)
+        self.assertAlmostEqual(fit.tcs[0].s, 0.01)
+
+    def test_old_object_cache_is_ignored_and_recomputed(self):
+        fit = self._make_fit()
+        old_payload = {
+            "singles": ["unsafe-pytransit-object"],
+            "post_samples": ["stale"],
+            "tcs": ["stale"],
+            "epochs": np.array([999]),
+        }
+
+        with open(self.cache_file, "wb") as f:
+            dill.dump(old_payload, f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("cmat.base.np.vectorize", side_effect=self._vectorize_factory):
+                with patch("cmat.base.tqdm", _DummyTqdm):
+                    with patch.object(fit, "fit_single", side_effect=self._fit_single_side_effect) as mock_fit_single:
+                        fit.fit_singles(use_cache=True, cache_path=self.cache_file)
+
+        self.assertEqual(mock_fit_single.call_count, 3)
+        self.assertTrue(
+            any("Ignoring fit_singles cache" in str(item.message) for item in caught)
+        )
+        np.testing.assert_array_equal(fit.epochs, np.array([5, 6, 7]))
+
+    def test_corrupted_dill_cache_is_ignored_and_recomputed(self):
+        fit = self._make_fit()
+        with open(self.cache_file, "wb") as f:
+            f.write(b"not-a-dill-payload")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("cmat.base.np.vectorize", side_effect=self._vectorize_factory):
+                with patch("cmat.base.tqdm", _DummyTqdm):
+                    with patch.object(fit, "fit_single", side_effect=self._fit_single_side_effect) as mock_fit_single:
+                        fit.fit_singles(use_cache=True, cache_path=self.cache_file)
+
+        self.assertEqual(mock_fit_single.call_count, 3)
+        self.assertTrue(
+            any("Ignoring fit_singles cache" in str(item.message) for item in caught)
+        )
+
+    def test_planet_name_mismatch_is_rejected_and_recomputed(self):
+        fit = self._make_fit()
+        payload = {
+            "cache_schema_version": "2",
+            "planet_name": "OtherPlanet",
+            "post_samples": [],
+            "tcs": [],
+            "epochs": np.array([], dtype=int),
+        }
+
+        with open(self.cache_file, "wb") as f:
+            dill.dump(payload, f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("cmat.base.np.vectorize", side_effect=self._vectorize_factory):
+                with patch("cmat.base.tqdm", _DummyTqdm):
+                    with patch.object(fit, "fit_single", side_effect=self._fit_single_side_effect) as mock_fit_single:
+                        fit.fit_singles(use_cache=True, cache_path=self.cache_file)
+
+        self.assertEqual(mock_fit_single.call_count, 3)
+        self.assertTrue(
+            any("planet_name mismatch" in str(item.message) for item in caught)
+        )
+
+    def test_saved_cache_does_not_contain_singles(self):
+        fit = self._make_fit()
+
+        with patch("cmat.base.np.vectorize", side_effect=self._vectorize_factory):
+            with patch("cmat.base.tqdm", _DummyTqdm):
+                with patch.object(fit, "fit_single", side_effect=self._fit_single_side_effect):
+                    fit.fit_singles(use_cache=True, cache_path=self.cache_file)
+
+        with open(self.cache_file, "rb") as f:
+            payload = dill.load(f)
+
+        self.assertEqual(payload["cache_schema_version"], "2")
+        self.assertEqual(payload["planet_name"], "TestPlanet")
+        self.assertNotIn("singles", payload)
+
+    def test_downstream_ttv_calculation_works_after_loading_cached_results(self):
+        fit = self._make_fit()
+        payload = {
+            "cache_schema_version": "2",
+            "planet_name": "TestPlanet",
+            "post_samples": [
+                {"tc": _FakeSeries(110.0, 0.01)},
+                {"tc": _FakeSeries(112.0, 0.02)},
+                {"tc": _FakeSeries(114.0, 0.03)},
+            ],
+            "tcs": [
+                importlib.import_module("cmat.base").ufloat(110.0, 0.01),
+                importlib.import_module("cmat.base").ufloat(112.0, 0.02),
+                importlib.import_module("cmat.base").ufloat(114.0, 0.03),
+            ],
+            "epochs": np.array([5, 6, 7]),
+        }
+
+        with open(self.cache_file, "wb") as f:
+            dill.dump(payload, f)
+
+        with patch.object(fit, "fit_single", side_effect=AssertionError("should not refit")):
+            fit.fit_singles(use_cache=True, cache_path=self.cache_file)
+
+        fit.calculate_ttv()
+
+        np.testing.assert_allclose(fit.ttv_mcmc, np.array([0.0, 0.0, 0.0]), atol=1e-8)
+        np.testing.assert_allclose(
+            fit.ttv_err,
+            np.array([0.01, 0.0201, 0.0302]) * importlib.import_module("cmat.base").DAY_TO_SEC,
+            atol=1e-8,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the fit_singles dill cache with a v2 lightweight result cache
- reject stale, mismatched, and corrupted caches with clear warnings before recomputing
- add regression coverage for cache reloads and downstream TTV use after cache restore

## Testing
- python3.11 -m unittest discover -s /private/tmp/cmat-fit-singles-cache-pr/tests -p 'test_base_cache.py'
